### PR TITLE
fix incomplete clear in function deserialise()

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1293,6 +1293,7 @@ namespace merkle
 
       delete (_root);
       leaf_nodes.clear();
+      this->statistics = Statistics{};
       for (auto n : uninserted_leaf_nodes)
         delete (n);
       uninserted_leaf_nodes.clear();


### PR DESCRIPTION
It seems that deserialise() will not reset the Statitics struct, which means that if you reuse a tree by deserialise() function, the count variable like num_hash will be accumulated.

btw thank you for this code, it is helpful for my graduation project. :)