### PR TITLE
fix incomplete clear in function deserialise()

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1293,6 +1293,7 @@ namespace merkle
 
       delete (_root);
       leaf_nodes.clear();
+      this->statistics = Statistics{};
       for (auto n : uninserted_leaf_nodes)
         delete (n);
       uninserted_leaf_nodes.clear();
@@ -1310,6 +1311,7 @@ namespace merkle
         Node* n = Node::make(bytes.data() + position);
         position += HASH_SIZE;
         leaf_nodes.push_back(n);
+        this->statistics.num_insert++;
       }
 
       std::vector<Node*> level = leaf_nodes, next_level;


### PR DESCRIPTION
It seems that deserialise() will not reset the Statistics struct, which means that if you use deserialise() function to a used tree, the statistics variable like num_insert will be accumulated to its previous value.
I don't know whether my change has correct all the statistics, but num_insert, num_hash and num_root seem to be OK.

btw thank you for this code, it is helpful for my graduation project. :)