### PR TITLE
Add function to zero out all the bytes in a Hash

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -153,6 +153,12 @@ namespace merkle
       return SIZE;
     }
 
+    /// @brief zeros out all bytes in the hash
+    void zero()
+    {
+      std::fill(bytes, bytes + SIZE, 0);
+    }
+
     /// @brief The size of the serialisation of the hash (in number of bytes)
     size_t serialised_size() const
     {


### PR DESCRIPTION
Adding a helper function to zero out all the bytes in a Hash. This is useful when including the Hash in a POD.