### PR TITLE
Support for OpenSSL 3.1

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -55,9 +55,6 @@ To enable these bindings, merklecpp requires the compiler macros
 .. doxygenfunction:: merkle::sha256_compress
    :project: merklecpp
 
-.. doxygenfunction:: merkle::sha256_compress_openssl
-   :project: merklecpp
-
 .. doxygenfunction:: merkle::sha256_openssl
    :project: merklecpp
 

--- a/merklecpp.h
+++ b/merklecpp.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #ifdef HAVE_OPENSSL
+#  include <openssl/evp.h>
 #  include <openssl/sha.h>
 #endif
 
@@ -1885,34 +1886,6 @@ namespace merkle
   // clang-format on
 
 #ifdef HAVE_OPENSSL
-  /// @brief OpenSSL's SHA256 compression function
-  /// @param l Left node hash
-  /// @param r Right node hash
-  /// @param out Output node hash
-  /// @note Some versions of OpenSSL may not provide SHA256_Transform.
-  static inline void sha256_compress_openssl(
-    const HashT<32>& l, const HashT<32>& r, HashT<32>& out)
-  {
-    unsigned char block[32 * 2];
-    memcpy(&block[0], l.bytes, 32);
-    memcpy(&block[32], r.bytes, 32);
-
-    const EVP_MD* md = EVP_sha256();
-    int rc = EVP_Digest(&block[0], 32 * 2, h, nullptr, md, nullptr);
-    if (rc != 1)
-    {
-      throw std::logic_error(fmt::format("EVP_Digest failed: {}", rc));
-    }
-
-    // SHA256_CTX ctx;
-    // if (SHA256_Init(&ctx) != 1)
-    //   printf("SHA256_Init error");
-    // SHA256_Transform(&ctx, &block[0]);
-
-    for (int i = 0; i < 8; i++)
-      ((uint32_t*)out.bytes)[i] = convert_endianness(((uint32_t*)ctx.h)[i]);
-  }
-
   /// @brief OpenSSL SHA256
   /// @param l Left node hash
   /// @param r Right node hash
@@ -1928,13 +1901,12 @@ namespace merkle
     memcpy(&block[32], r.bytes, 32);
 
     const EVP_MD* md = EVP_sha256();
-    int rc = EVP_Digest(&block[0], sizeof(block), h, nullptr, md, nullptr);
+    int rc =
+      EVP_Digest(&block[0], sizeof(block), out.bytes, nullptr, md, nullptr);
     if (rc != 1)
     {
-      throw std::logic_error(fmt::format("EVP_Digest failed: {}", rc));
+      throw std::runtime_error("EVP_Digest failed: " + std::to_string(rc));
     }
-
-    // SHA256(block, sizeof(block), out.bytes);
   }
 #endif
 

--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1390,7 +1390,8 @@ namespace merkle
       if (index >= num_leaves())
         throw std::runtime_error("leaf index out of bounds");
       if (index - num_flushed >= leaf_nodes.size())
-        return uninserted_leaf_nodes.at(index - num_flushed - leaf_nodes.size())
+        return uninserted_leaf_nodes
+          .at(index - num_flushed - leaf_nodes.size())
           ->hash;
       else
         return leaf_nodes.at(index - num_flushed)->hash;
@@ -1622,7 +1623,8 @@ namespace merkle
       if (index >= num_leaves())
         throw std::runtime_error("leaf index out of bounds");
       if (index - num_flushed >= leaf_nodes.size())
-        return uninserted_leaf_nodes.at(index - num_flushed - leaf_nodes.size());
+        return uninserted_leaf_nodes.at(
+          index - num_flushed - leaf_nodes.size());
       else
         return leaf_nodes.at(index - num_flushed);
     }
@@ -1734,7 +1736,8 @@ namespace merkle
       MERKLECPP_TRACE({
         std::string nodes;
         for (size_t i = 0; i < insertion_stack.size(); i++)
-          nodes += " " + insertion_stack.at(i).n->hash.to_string(TRACE_HASH_SIZE);
+          nodes +=
+            " " + insertion_stack.at(i).n->hash.to_string(TRACE_HASH_SIZE);
         MERKLECPP_TOUT << "  X " << (complete ? "complete" : "continue") << ":"
                        << nodes << std::endl;
       });
@@ -1894,10 +1897,17 @@ namespace merkle
     memcpy(&block[0], l.bytes, 32);
     memcpy(&block[32], r.bytes, 32);
 
-    SHA256_CTX ctx;
-    if (SHA256_Init(&ctx) != 1)
-      printf("SHA256_Init error");
-    SHA256_Transform(&ctx, &block[0]);
+    const EVP_MD* md = EVP_sha256();
+    int rc = EVP_Digest(&block[0], 32 * 2, h, nullptr, md, nullptr);
+    if (rc != 1)
+    {
+      throw std::logic_error(fmt::format("EVP_Digest failed: {}", rc));
+    }
+
+    // SHA256_CTX ctx;
+    // if (SHA256_Init(&ctx) != 1)
+    //   printf("SHA256_Init error");
+    // SHA256_Transform(&ctx, &block[0]);
 
     for (int i = 0; i < 8; i++)
       ((uint32_t*)out.bytes)[i] = convert_endianness(((uint32_t*)ctx.h)[i]);
@@ -1916,7 +1926,15 @@ namespace merkle
     uint8_t block[32 * 2];
     memcpy(&block[0], l.bytes, 32);
     memcpy(&block[32], r.bytes, 32);
-    SHA256(block, sizeof(block), out.bytes);
+
+    const EVP_MD* md = EVP_sha256();
+    int rc = EVP_Digest(&block[0], sizeof(block), h, nullptr, md, nullptr);
+    if (rc != 1)
+    {
+      throw std::logic_error(fmt::format("EVP_Digest failed: {}", rc));
+    }
+
+    // SHA256(block, sizeof(block), out.bytes);
   }
 #endif
 

--- a/test/compare_hash_functions.cpp
+++ b/test/compare_hash_functions.cpp
@@ -47,7 +47,6 @@ typedef merkle::TreeT<32, sha256_evercrypt> EverCryptFullTree;
 #endif
 
 #ifdef HAVE_OPENSSL
-typedef merkle::TreeT<32, merkle::sha256_compress_openssl> OpenSSLTree;
 typedef merkle::TreeT<32, merkle::sha256_openssl> OpenSSLFullTree;
 #endif
 
@@ -103,10 +102,6 @@ void compare_compression_hashes()
     EverCryptTree mte;
 #endif
 
-#ifdef HAVE_OPENSSL
-    OpenSSLTree mto;
-#endif
-
 #ifdef HAVE_MBEDTLS
     MbedTLSTree mtm;
 #endif
@@ -123,10 +118,6 @@ void compare_compression_hashes()
       mte.insert(h);
 #endif
 
-#ifdef HAVE_OPENSSL
-      mto.insert(h);
-#endif
-
 #ifdef HAVE_MBEDTLS
       mtm.insert(h);
 #endif
@@ -139,10 +130,6 @@ void compare_compression_hashes()
         compare_roots(mt, mte, "EverCrypt");
 #endif
 
-#ifdef HAVE_OPENSSL
-        compare_roots(mt, mto, "OpenSSL");
-#endif
-
 #ifdef HAVE_MBEDTLS
         compare_roots(mt, mtm, "mbedTLS");
 #endif
@@ -153,10 +140,6 @@ void compare_compression_hashes()
 
 #ifdef HAVE_EVERCRYPT
     compare_roots(mt, mte, "EverCrypt");
-#endif
-
-#ifdef HAVE_OPENSSL
-    compare_roots(mt, mto, "OpenSSL");
 #endif
 
 #ifdef HAVE_MBEDTLS
@@ -328,10 +311,6 @@ int main()
               << std::endl;
 
     bench<merkle::Tree>(hashes, "merklecpp", root_interval);
-
-#ifdef HAVE_OPENSSL
-    bench<OpenSSLTree>(hashes, "OpenSSL", root_interval);
-#endif
 
 #ifdef HAVE_MBEDTLS
     bench<MbedTLSTree>(hashes, "mbedTLS", root_interval);


### PR DESCRIPTION
This also removes `sha256_compress_openssl` which isn't used by https://github.com/microsoft/ccf and `SHA256_Transform` doesn't have an equivalent `EVP_` API in OpenSSL 3.1. 