### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,9 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/merklecpp/security/code-scanning/7](https://github.com/microsoft/merklecpp/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block declaring the least privileges the workflow needs. For a standard CodeQL analysis workflow that only checks out code and runs analysis, that typically means read access to repository contents (`contents: read`) and allowing the CodeQL action to upload security analysis results (`security-events: write`). These permissions can be set at the workflow root (applies to all jobs) or on the individual job.

For this specific file `.github/workflows/codeql-analysis.yml`, the minimal, non-breaking change is to add a `permissions` block under the `analyze` job (indented to match other job keys like `name`, `runs-on`, and `strategy`). This keeps the permissions local to this job and avoids affecting any other jobs that might be added later. Insert:

```yaml
    permissions:
      contents: read
      security-events: write
```

between `runs-on: ubuntu-latest` (line 15) and `strategy:` (line 17). No additional imports or definitions are needed because this is purely a YAML configuration change. Existing behavior of the CodeQL workflow remains the same, while the `GITHUB_TOKEN` is now explicitly restricted to the minimum needed scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
