### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Sphinx Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Check out sources


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/merklecpp/security/code-scanning/6](https://github.com/microsoft/merklecpp/security/code-scanning/6)

To fix the problem, the workflow should explicitly declare the least-privilege `permissions` required for the job, rather than relying on repository or organization defaults. In this case, the job needs to be able to push commits to the `gh-pages` branch, which requires `contents: write`. There is no evidence that it needs any other scopes (`issues`, `pull-requests`, etc.), so we should keep those omitted (defaulting to `none`).

The single best fix without changing functionality is to add a `permissions` block to the `build` job in `.github/workflows/build-docs.yml`, directly under the job’s name or `runs-on`. For example:

```yaml
jobs:
  build:
    name: Sphinx Build
    runs-on: ubuntu-latest
    permissions:
      contents: write
```

This constrains the `GITHUB_TOKEN` used by the job (including in `actions/checkout` and `ad-m/github-push-action`) to repository contents write access only, matching the workflow’s needs. No additional imports or external methods are required, as this is purely a YAML configuration change within the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
