### PR TITLE
Update CodeQL actions to v4.37.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,4 +50,4 @@ jobs:
       run: cmake --build . --config Debug
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
Updates every `github/codeql-action` reference in `.github/workflows/codeql-analysis.yml` from v4.36.2 to v4.37.6:

- `github/codeql-action/init`
- `github/codeql-action/analyze`

Both actions remain pinned to the immutable release commit `5595ccaf912efad79be6eef63a5619ff05969be3`.

Upstream release: https://github.com/github/codeql-action/releases/tag/v4.37.6