### PR TITLE
Parameterize tiled storage geometry

### DIFF
--- a/merklecpp_tiles.h
+++ b/merklecpp_tiles.h
@@ -1196,12 +1196,24 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       static constexpr size_t DEFAULT_TILE_CACHE_SIZE = 64;
       static constexpr size_t TILE_CACHE_HASH_BUDGET =
         DEFAULT_TILE_CACHE_SIZE * DEFAULT_TILE_WIDTH;
-      static constexpr size_t TILE_CACHE_SIZE =
-        TILE_WIDTH < DEFAULT_TILE_WIDTH ?
-        DEFAULT_TILE_CACHE_SIZE :
-        (TILE_CACHE_HASH_BUDGET / TILE_WIDTH == 0 ?
-           1 :
-           TILE_CACHE_HASH_BUDGET / TILE_WIDTH);
+
+      static constexpr size_t tile_cache_size()
+      {
+        if constexpr (TILE_WIDTH <= DEFAULT_TILE_WIDTH)
+        {
+          return DEFAULT_TILE_CACHE_SIZE;
+        }
+        else if constexpr (TILE_WIDTH > TILE_CACHE_HASH_BUDGET)
+        {
+          return 1;
+        }
+        else
+        {
+          return TILE_CACHE_HASH_BUDGET / TILE_WIDTH;
+        }
+      }
+
+      static constexpr size_t TILE_CACHE_SIZE = tile_cache_size();
       mutable std::vector<TileCacheEntry> tile_cache;
 
       const std::vector<Hash>& read_tile(const TileRef& ref) const

--- a/merklecpp_tiles.h
+++ b/merklecpp_tiles.h
@@ -51,12 +51,6 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     static constexpr uint16_t DEFAULT_TILE_WIDTH =
       uint16_t{1U << DEFAULT_TILE_HEIGHT};
 
-    /// @brief Backward-compatible alias for the default tile height.
-    static constexpr uint16_t TILE_HEIGHT = DEFAULT_TILE_HEIGHT;
-
-    /// @brief Backward-compatible alias for the default tile width.
-    static constexpr uint16_t TILE_WIDTH = DEFAULT_TILE_WIDTH;
-
     /// @brief Highest tile level permitted by the tlog-tiles layout.
     static constexpr uint8_t MAX_TILE_LEVEL = 63;
 

--- a/merklecpp_tiles.h
+++ b/merklecpp_tiles.h
@@ -26,9 +26,10 @@
 
 // Tiled storage for merklecpp trees, following the full-tile geometry, payload,
 // and path encoding of the C2SP tlog-tiles layout
-// (https://c2sp.org/tlog-tiles). C2SP defines SHA-256; merklecpp preserves the
-// 256-hash tile width for other SHA output sizes and separates each format
-// under an algorithm-qualified directory such as sha256-256w or sha384-256w.
+// (https://c2sp.org/tlog-tiles). C2SP defines SHA-256 and 256-hash tiles.
+// merklecpp uses that geometry by default, supports compile-time power-of-two
+// tile widths as an extension, and separates each format under an
+// algorithm-and-width-qualified directory such as sha256-256w or sha384-16w.
 // Only complete, immutable tiles are stored. Their hash values are produced by
 // the tree's existing HASH_FUNCTION, so tile-derived proofs are byte-identical
 // to those produced by merkle::TreeT.
@@ -43,11 +44,18 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
 {
   namespace tiles
   {
-    /// @brief Number of tree levels spanned by a single tile.
-    static constexpr uint16_t TILE_HEIGHT = 8;
+    /// @brief Default number of tree levels spanned by a single tile.
+    static constexpr uint16_t DEFAULT_TILE_HEIGHT = 8;
 
-    /// @brief Number of hashes in a full tile (2**TILE_HEIGHT).
-    static constexpr uint16_t TILE_WIDTH = uint16_t{1U << TILE_HEIGHT};
+    /// @brief Default number of hashes in a full tile.
+    static constexpr uint16_t DEFAULT_TILE_WIDTH =
+      uint16_t{1U << DEFAULT_TILE_HEIGHT};
+
+    /// @brief Backward-compatible alias for the default tile height.
+    static constexpr uint16_t TILE_HEIGHT = DEFAULT_TILE_HEIGHT;
+
+    /// @brief Backward-compatible alias for the default tile width.
+    static constexpr uint16_t TILE_WIDTH = DEFAULT_TILE_WIDTH;
 
     /// @brief Highest tile level permitted by the tlog-tiles layout.
     static constexpr uint8_t MAX_TILE_LEVEL = 63;
@@ -73,8 +81,30 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       static constexpr std::string_view SHA512_ALGORITHM_SHORT_NAME = "sha512";
       static constexpr size_t ENTRY_LENGTH_PREFIX_SIZE = 2;
       static constexpr size_t MAX_ENTRY_SIZE = 0xFFFF;
-      static constexpr size_t MAX_ENTRY_BUNDLE_SIZE =
-        TILE_WIDTH * (ENTRY_LENGTH_PREFIX_SIZE + MAX_ENTRY_SIZE);
+
+      template <uint8_t TILE_HEIGHT_VALUE>
+      struct TileGeometry
+      {
+        static_assert(
+          TILE_HEIGHT_VALUE > 0,
+          "tile height must be greater than zero");
+        static_assert(
+          TILE_HEIGHT_VALUE < std::numeric_limits<size_t>::digits,
+          "tile width must fit in size_t");
+
+        static constexpr uint8_t HEIGHT = TILE_HEIGHT_VALUE;
+        static constexpr size_t WIDTH = size_t{1} << HEIGHT;
+        static constexpr size_t MAX_ENCODED_ENTRY_SIZE =
+          ENTRY_LENGTH_PREFIX_SIZE + MAX_ENTRY_SIZE;
+
+        static_assert(
+          WIDTH <=
+            std::numeric_limits<size_t>::max() / MAX_ENCODED_ENTRY_SIZE,
+          "maximum entry bundle size must fit in size_t");
+
+        static constexpr size_t MAX_ENTRY_BUNDLE_SIZE =
+          WIDTH * MAX_ENCODED_ENTRY_SIZE;
+      };
 
       template <typename Present>
       uint64_t contiguous_prefix_length(uint64_t limit, const Present& present)
@@ -118,8 +148,8 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     }
 
     /// @brief Identifies a single (full) tile within a tiled log.
-    /// @note Only full, TILE_WIDTH-wide tiles are produced and consumed; the
-    /// incomplete frontier is never tiled.
+    /// @note Only full tiles of the associated store's width are produced and
+    /// consumed; the incomplete frontier is never tiled.
     struct TileRef
     {
       /// @brief The level of the tile (0 == leaf hashes, maximum 63).
@@ -132,19 +162,24 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
     class TileWriterT;
 
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
     class EntryBundleWriterT;
 
     /// @brief Reads and writes tlog-tiles tile files on a local filesystem.
     /// @tparam HASH_SIZE Size of each hash in bytes
     /// @tparam HASH_FUNCTION The tree's node hash function (carried for use by
     /// later components; tile I/O itself does not hash).
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile;
+    /// the tile width is 2**TILE_HEIGHT_VALUE. The default value 8 is the C2SP
+    /// tlog-tiles geometry; other values are merklecpp extensions.
     /// @warning No internal synchronization is provided. Callers must serialize
     /// access to each store object and all writers sharing its prefix.
     /// Independent store objects may read while the serialized writer publishes
@@ -152,15 +187,36 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
     class TileStoreT
     {
-      friend class TileWriterT<HASH_SIZE, HASH_FUNCTION>;
-      friend class EntryBundleWriterT<HASH_SIZE, HASH_FUNCTION>;
+      friend class TileWriterT<
+        HASH_SIZE,
+        HASH_FUNCTION,
+        TILE_HEIGHT_VALUE>;
+      friend class EntryBundleWriterT<
+        HASH_SIZE,
+        HASH_FUNCTION,
+        TILE_HEIGHT_VALUE>;
 
     public:
       /// @brief The type of hashes stored in tiles.
       using Hash = HashT<HASH_SIZE>;
+
+      /// @brief The compile-time tile geometry.
+      using Geometry = detail::TileGeometry<TILE_HEIGHT_VALUE>;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
+
+      static_assert(
+        HASH_SIZE > 0 &&
+          TILE_WIDTH <= std::numeric_limits<size_t>::max() / HASH_SIZE,
+        "tile byte size must fit in size_t");
 
       /// @brief Constructs a tile store below an algorithm-qualified directory
       /// under @p prefix.
@@ -186,7 +242,7 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       }
 
       /// @brief The format directory for @p hash_algorithm_short_name.
-      /// @note TILE_WIDTH is fixed at 256 for every hash output size.
+      /// @note The default geometry produces names such as sha256-256w.
       static std::string storage_directory_name(
         const std::string& hash_algorithm_short_name)
       {
@@ -282,7 +338,7 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
         std::vector<Hash> hashes;
         hashes.reserve(TILE_WIDTH);
         size_t position = 0;
-        for (uint16_t i = 0; i < TILE_WIDTH; i++)
+        for (size_t i = 0; i < TILE_WIDTH; i++)
         {
           hashes.emplace_back(bytes, position);
         }
@@ -301,7 +357,7 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
         try
         {
           (void)decode_entries(
-            read_file(path, detail::MAX_ENTRY_BUNDLE_SIZE), TILE_WIDTH);
+            read_file(path, Geometry::MAX_ENTRY_BUNDLE_SIZE), TILE_WIDTH);
           return true;
         }
         catch (const std::runtime_error&)
@@ -332,7 +388,7 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
         uint64_t index) const
       {
         const auto path = entries_path(index);
-        const auto bytes = read_file(path, detail::MAX_ENTRY_BUNDLE_SIZE);
+        const auto bytes = read_file(path, Geometry::MAX_ENTRY_BUNDLE_SIZE);
         try
         {
           return decode_entries(bytes, TILE_WIDTH);
@@ -811,11 +867,12 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     /// @brief Computes and persists tlog-tiles tiles for a growing tree.
     /// @tparam HASH_SIZE Size of each hash in bytes
     /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile
     /// @note Only balanced subtrees are tiled: a level-L entry is the root of a
-    /// complete 2**(8L)-leaf subtree. Only full tiles (256 such entries) are
-    /// written; they are therefore immutable and written exactly once. Entries
-    /// beyond the last full-tile boundary remain in memory until a later flush
-    /// completes the next tile.
+    /// complete 2**(TILE_HEIGHT_VALUE*L)-leaf subtree. Only full tiles are
+    /// written; they are therefore immutable and written exactly once.
+    /// Entries beyond the last full-tile boundary remain in memory until a
+    /// later flush completes the next tile.
     /// @warning No internal synchronization is provided. Callers must serialize
     /// access to a writer and its store.
     /// @warning A writer trusts existing full tiles as output from the same
@@ -824,7 +881,8 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE>
     class TileWriterT
     {
     public:
@@ -832,7 +890,17 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       using Hash = HashT<HASH_SIZE>;
 
       /// @brief The associated tile store type.
-      using Store = TileStoreT<HASH_SIZE, HASH_FUNCTION>;
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+
+      /// @brief The compile-time tile geometry.
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
 
       /// @brief Supplies the level-0 leaf hash for a given leaf index.
       using LeafFn = std::function<const Hash&(uint64_t)>;
@@ -963,7 +1031,7 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
           }
           else
           {
-            // Roll up the complete child full tile (256 complete entries).
+            // Roll up the complete child full tile.
             out.push_back(
               perfect_root<HASH_SIZE, HASH_FUNCTION>(
                 store.read_tile(TileRef{(uint8_t)(level - 1), g})));
@@ -1003,6 +1071,9 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     };
 
     /// @brief Resolves subtree roots from tlog-tiles tile files.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile
     /// @note @p available_size is rounded down to a whole number of full tiles:
     /// only complete, durably-written full tiles are read. A complete subtree
     /// within that full-tile prefix is resolvable; anything reaching into the
@@ -1014,12 +1085,23 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
     class TileHashSourceT : public HashSourceT<HASH_SIZE, HASH_FUNCTION>
     {
     public:
       using Hash = HashT<HASH_SIZE>;
-      using Store = TileStoreT<HASH_SIZE, HASH_FUNCTION>;
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+
+      /// @brief The compile-time tile geometry.
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
 
       /// @brief Constructs a source over @p store for trees up to
       /// @p available_size leaves. @p available_size is rounded down to a whole
@@ -1111,7 +1193,15 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
         std::vector<Hash> hashes;
       };
 
-      static constexpr size_t TILE_CACHE_SIZE = 64;
+      static constexpr size_t DEFAULT_TILE_CACHE_SIZE = 64;
+      static constexpr size_t TILE_CACHE_HASH_BUDGET =
+        DEFAULT_TILE_CACHE_SIZE * DEFAULT_TILE_WIDTH;
+      static constexpr size_t TILE_CACHE_SIZE =
+        TILE_WIDTH < DEFAULT_TILE_WIDTH ?
+        DEFAULT_TILE_CACHE_SIZE :
+        (TILE_CACHE_HASH_BUDGET / TILE_WIDTH == 0 ?
+           1 :
+           TILE_CACHE_HASH_BUDGET / TILE_WIDTH);
       mutable std::vector<TileCacheEntry> tile_cache;
 
       const std::vector<Hash>& read_tile(const TileRef& ref) const
@@ -1510,6 +1600,9 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     };
 
     /// @brief A merkle tree backed by tlog-tiles storage.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a tile
     /// @note Appends grow an in-memory tree; flush() durably writes only full
     /// (balanced) tiles, so the incomplete frontier is never tiled and stays
     /// resident in memory. Compaction (dropping from memory the leaves already
@@ -1527,16 +1620,26 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE = DEFAULT_TILE_HEIGHT>
     class TiledTreeT
     {
     public:
       using Hash = HashT<HASH_SIZE>;
       using Tree = TreeT<HASH_SIZE, HASH_FUNCTION>;
       using Path = PathT<HASH_SIZE, HASH_FUNCTION>;
-      using Store = TileStoreT<HASH_SIZE, HASH_FUNCTION>;
-      using Writer = TileWriterT<HASH_SIZE, HASH_FUNCTION>;
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+      using Writer =
+        TileWriterT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
       using Stats = typename Writer::Stats;
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one tile.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of hashes in one full tile.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
 
       // This wrapper mirrors the core tree's index type on its own public
       // surface, so leaf counts and indices pass through untouched and cross
@@ -1840,7 +1943,8 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       auto with_engine(Fn fn)
       {
         MemoryHashSourceT<HASH_SIZE, HASH_FUNCTION> mem(tree);
-        TileHashSourceT<HASH_SIZE, HASH_FUNCTION> tile_src(store, tiles_size);
+        TileHashSourceT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE> tile_src(
+          store, tiles_size);
         CombinedHashSourceT<HASH_SIZE, HASH_FUNCTION> combined(mem, tile_src);
         ProofEngineT<HASH_SIZE, HASH_FUNCTION> engine(combined);
         return fn(engine);
@@ -1849,6 +1953,9 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
 
     /// @brief Writes tlog-tiles entry bundles (raw log entries) for a growing
     /// log.
+    /// @tparam HASH_SIZE Size of each hash in bytes
+    /// @tparam HASH_FUNCTION The tree's node hash function
+    /// @tparam TILE_HEIGHT_VALUE Number of tree levels represented by a bundle
     /// @note Entry bundles are level-0 only and application-owned: merklecpp
     /// stores leaf hashes, while the raw entries (and the leaf-hash derivation
     /// linking each entry to its level-0 tile hash) are the application's
@@ -1861,11 +1968,20 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     template <
       size_t HASH_SIZE,
       void HASH_FUNCTION(
-        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&)>
+        const HashT<HASH_SIZE>&, const HashT<HASH_SIZE>&, HashT<HASH_SIZE>&),
+      uint8_t TILE_HEIGHT_VALUE>
     class EntryBundleWriterT
     {
     public:
-      using Store = TileStoreT<HASH_SIZE, HASH_FUNCTION>;
+      using Store =
+        TileStoreT<HASH_SIZE, HASH_FUNCTION, TILE_HEIGHT_VALUE>;
+      using Geometry = typename Store::Geometry;
+
+      /// @brief Number of tree levels represented by one bundle.
+      static constexpr uint8_t TILE_HEIGHT = Geometry::HEIGHT;
+
+      /// @brief Number of entries in one full bundle.
+      static constexpr size_t TILE_WIDTH = Geometry::WIDTH;
 
       /// @brief Supplies the raw bytes of the log entry at a given index.
       using EntryFn = std::function<std::vector<uint8_t>(uint64_t)>;
@@ -1945,11 +2061,17 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
 
     /// @brief Default tile store (SHA256, default hash function).
     using TileStore =
-      TileStoreT<merkle::Tree::Hash::size_bytes, merkle::Tree::hash_function>;
+      TileStoreT<
+        merkle::Tree::Hash::size_bytes,
+        merkle::Tree::hash_function,
+        DEFAULT_TILE_HEIGHT>;
 
     /// @brief Default tile writer (SHA256, default hash function).
     using TileWriter =
-      TileWriterT<merkle::Tree::Hash::size_bytes, merkle::Tree::hash_function>;
+      TileWriterT<
+        merkle::Tree::Hash::size_bytes,
+        merkle::Tree::hash_function,
+        DEFAULT_TILE_HEIGHT>;
 
     /// @brief Default abstract hash source (SHA256, default hash function).
     using HashSource =
@@ -1958,7 +2080,8 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     /// @brief Default tile-backed hash source (SHA256, default hash function).
     using TileHashSource = TileHashSourceT<
       merkle::Tree::Hash::size_bytes,
-      merkle::Tree::hash_function>;
+      merkle::Tree::hash_function,
+      DEFAULT_TILE_HEIGHT>;
 
     /// @brief Default proof engine (SHA256, default hash function).
     using ProofEngine =
@@ -1976,49 +2099,63 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
 
     /// @brief Default tiled tree (SHA256, default hash function).
     using TiledTree =
-      TiledTreeT<merkle::Tree::Hash::size_bytes, merkle::Tree::hash_function>;
+      TiledTreeT<
+        merkle::Tree::Hash::size_bytes,
+        merkle::Tree::hash_function,
+        DEFAULT_TILE_HEIGHT>;
 
     /// @brief Default entry-bundle writer (SHA256, default hash function).
     using EntryBundleWriter = EntryBundleWriterT<
       merkle::Tree::Hash::size_bytes,
-      merkle::Tree::hash_function>;
+      merkle::Tree::hash_function,
+      DEFAULT_TILE_HEIGHT>;
 
 #ifdef HAVE_OPENSSL
     /// @brief SHA384 tile store.
-    using TileStore384 = TileStoreT<48, sha384_openssl>;
+    using TileStore384 =
+      TileStoreT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
 
     /// @brief SHA512 tile store.
-    using TileStore512 = TileStoreT<64, sha512_openssl>;
+    using TileStore512 =
+      TileStoreT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
 
     /// @brief SHA384 tile writer.
-    using TileWriter384 = TileWriterT<48, sha384_openssl>;
+    using TileWriter384 =
+      TileWriterT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
 
     /// @brief SHA512 tile writer.
-    using TileWriter512 = TileWriterT<64, sha512_openssl>;
+    using TileWriter512 =
+      TileWriterT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
 
     /// @brief SHA384 hash source, tile-backed source and proof engine.
     using HashSource384 = HashSourceT<48, sha384_openssl>;
-    using TileHashSource384 = TileHashSourceT<48, sha384_openssl>;
+    using TileHashSource384 =
+      TileHashSourceT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
     using ProofEngine384 = ProofEngineT<48, sha384_openssl>;
 
     /// @brief SHA512 hash source, tile-backed source and proof engine.
     using HashSource512 = HashSourceT<64, sha512_openssl>;
-    using TileHashSource512 = TileHashSourceT<64, sha512_openssl>;
+    using TileHashSource512 =
+      TileHashSourceT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
     using ProofEngine512 = ProofEngineT<64, sha512_openssl>;
 
     /// @brief SHA384 memory/combined sources and tiled tree.
     using MemoryHashSource384 = MemoryHashSourceT<48, sha384_openssl>;
     using CombinedHashSource384 = CombinedHashSourceT<48, sha384_openssl>;
-    using TiledTree384 = TiledTreeT<48, sha384_openssl>;
+    using TiledTree384 =
+      TiledTreeT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
 
     /// @brief SHA512 memory/combined sources and tiled tree.
     using MemoryHashSource512 = MemoryHashSourceT<64, sha512_openssl>;
     using CombinedHashSource512 = CombinedHashSourceT<64, sha512_openssl>;
-    using TiledTree512 = TiledTreeT<64, sha512_openssl>;
+    using TiledTree512 =
+      TiledTreeT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
 
     /// @brief SHA384/512 entry-bundle writers.
-    using EntryBundleWriter384 = EntryBundleWriterT<48, sha384_openssl>;
-    using EntryBundleWriter512 = EntryBundleWriterT<64, sha512_openssl>;
+    using EntryBundleWriter384 =
+      EntryBundleWriterT<48, sha384_openssl, DEFAULT_TILE_HEIGHT>;
+    using EntryBundleWriter512 =
+      EntryBundleWriterT<64, sha512_openssl, DEFAULT_TILE_HEIGHT>;
 #endif
   }
 }

--- a/merklecpp_tiles.h
+++ b/merklecpp_tiles.h
@@ -6,6 +6,7 @@
 #include "merklecpp.h"
 #include "merklecpp_pal.h"
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -1190,24 +1191,10 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       static constexpr size_t DEFAULT_TILE_CACHE_SIZE = 64;
       static constexpr size_t TILE_CACHE_HASH_BUDGET =
         DEFAULT_TILE_CACHE_SIZE * DEFAULT_TILE_WIDTH;
-
-      static constexpr size_t tile_cache_size()
-      {
-        if constexpr (TILE_WIDTH <= DEFAULT_TILE_WIDTH)
-        {
-          return DEFAULT_TILE_CACHE_SIZE;
-        }
-        else if constexpr (TILE_WIDTH > TILE_CACHE_HASH_BUDGET)
-        {
-          return 1;
-        }
-        else
-        {
-          return TILE_CACHE_HASH_BUDGET / TILE_WIDTH;
-        }
-      }
-
-      static constexpr size_t TILE_CACHE_SIZE = tile_cache_size();
+      static constexpr size_t TILE_CACHE_SIZE = std::clamp(
+        TILE_CACHE_HASH_BUDGET / TILE_WIDTH,
+        size_t{1},
+        DEFAULT_TILE_CACHE_SIZE);
       mutable std::vector<TileCacheEntry> tile_cache;
 
       const std::vector<Hash>& read_tile(const TileRef& ref) const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -42,6 +42,7 @@ add_merklecpp_test(tiles_writer tiles_writer.cpp)
 add_merklecpp_test(tiles_proofs tiles_proofs.cpp)
 add_merklecpp_test(tiles_tree tiles_tree.cpp)
 add_merklecpp_test(tiles_entries tiles_entries.cpp)
+add_merklecpp_test(tiles_geometry tiles_geometry.cpp)
 
 if(OPENSSL)
   add_merklecpp_test(tiles_hashes tiles_hashes.cpp)

--- a/test/tiles_entries.cpp
+++ b/test/tiles_entries.cpp
@@ -155,9 +155,9 @@ int main()
         writer.write_up_to(2048, entry_at).full_written == 1,
         "holes rewrites interior bundle");
       std::vector<std::vector<uint8_t>> expected;
-      expected.reserve(merkle::tiles::TILE_WIDTH);
-      constexpr uint64_t hole_begin = (uint64_t)merkle::tiles::TILE_WIDTH * 3;
-      constexpr uint64_t hole_end = (uint64_t)merkle::tiles::TILE_WIDTH * 4;
+      expected.reserve(TileStore::TILE_WIDTH);
+      constexpr uint64_t hole_begin = (uint64_t)TileStore::TILE_WIDTH * 3;
+      constexpr uint64_t hole_end = (uint64_t)TileStore::TILE_WIDTH * 4;
       for (uint64_t i = hole_begin; i < hole_end; i++)
       {
         expected.push_back(entry_at(i));
@@ -171,7 +171,7 @@ int main()
     {
       const fs::path dir = base / "esparse";
       const std::vector<std::vector<uint8_t>> bundle(
-        merkle::tiles::TILE_WIDTH, {0x42});
+        TileStore::TILE_WIDTH, {0x42});
       {
         TileStore store(dir);
         store.write_entry_bundle(0, bundle);
@@ -188,7 +188,7 @@ int main()
       TileStore store(dir);
       EntryBundleWriter writer(store);
       expect(
-        writer.write_up_to(merkle::tiles::TILE_WIDTH, entry_at).full_written ==
+        writer.write_up_to(TileStore::TILE_WIDTH, entry_at).full_written ==
           0,
         "sparse bounded recovery");
       expect(

--- a/test/tiles_geometry.cpp
+++ b/test/tiles_geometry.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "tiles_test_util.h"
+#include "util.h"
+
+#include <cstdint>
+#include <doctest/doctest.h>
+#include <filesystem>
+#include <fstream>
+#include <merklecpp.h>
+#include <merklecpp_tiles.h>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace fs = std::filesystem;
+using merkle::Hash;
+using merkle::tiles::CombinedHashSource;
+using merkle::tiles::MemoryHashSource;
+using merkle::tiles::ProofEngine;
+using merkle::tiles::TileRef;
+
+static constexpr uint8_t SMALL_TILE_HEIGHT = 2;
+using SmallStore = merkle::tiles::TileStoreT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  SMALL_TILE_HEIGHT>;
+using SmallWriter = merkle::tiles::TileWriterT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  SMALL_TILE_HEIGHT>;
+using SmallTileHashSource = merkle::tiles::TileHashSourceT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  SMALL_TILE_HEIGHT>;
+using SmallTiledTree = merkle::tiles::TiledTreeT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  SMALL_TILE_HEIGHT>;
+using SmallEntryBundleWriter = merkle::tiles::EntryBundleWriterT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  SMALL_TILE_HEIGHT>;
+
+static_assert(merkle::tiles::TileStore::TILE_HEIGHT == 8);
+static_assert(merkle::tiles::TileStore::TILE_WIDTH == 256);
+static_assert(SmallStore::TILE_HEIGHT == SMALL_TILE_HEIGHT);
+static_assert(SmallStore::TILE_WIDTH == 4);
+static_assert(std::is_same_v<SmallWriter::Store, SmallStore>);
+static_assert(std::is_same_v<SmallTileHashSource::Store, SmallStore>);
+static_assert(std::is_same_v<SmallTiledTree::Store, SmallStore>);
+static_assert(std::is_same_v<SmallEntryBundleWriter::Store, SmallStore>);
+
+static constexpr uint64_t SMALL_LEVEL1_SIZE =
+  SmallStore::TILE_WIDTH * SmallStore::TILE_WIDTH;
+static constexpr uint64_t SMALL_LEVEL2_SIZE =
+  SMALL_LEVEL1_SIZE * SmallStore::TILE_WIDTH;
+static constexpr uint64_t SMALL_LEVEL2_TILE_COUNT =
+  SMALL_LEVEL1_SIZE + SmallStore::TILE_WIDTH + 1;
+
+static void overwrite_file(const fs::path& path)
+{
+  std::ofstream file(path, std::ios::binary | std::ios::trunc);
+  const std::vector<uint8_t> bytes = {0x00, 0x05, 0x01};
+  file.write(
+    reinterpret_cast<const char*>(bytes.data()),
+    static_cast<std::streamsize>(bytes.size()));
+}
+
+static void check_proofs(
+  const fs::path& prefix,
+  uint64_t size,
+  const std::vector<Hash>& hashes)
+{
+  SmallStore store(prefix);
+  SmallWriter writer(store);
+  const auto leaf_at = [&](uint64_t index) -> const Hash& {
+    return hashes[index];
+  };
+  const auto stats = writer.write_up_to(size, leaf_at);
+
+  merkle::Tree reference;
+  merkle::Tree frontier;
+  for (uint64_t index = 0; index < size; index++)
+  {
+    reference.insert(hashes[index]);
+    frontier.insert(hashes[index]);
+  }
+
+  const uint64_t covered =
+    (size / SmallStore::TILE_WIDTH) * SmallStore::TILE_WIDTH;
+  uint64_t drop_to = covered;
+  if (drop_to >= size)
+  {
+    drop_to = size - 1;
+  }
+  if (drop_to > 0)
+  {
+    frontier.flush_to(static_cast<size_t>(drop_to));
+  }
+
+  const MemoryHashSource memory_source(frontier);
+  const SmallTileHashSource tile_source(store, covered);
+  const CombinedHashSource source(memory_source, tile_source);
+  const ProofEngine engine(source);
+  const Hash expected_root = reference.root();
+
+  CHECK(engine.root(size) == expected_root);
+  for (const uint64_t index : {uint64_t{0}, size - 1})
+  {
+    const auto proof = engine.inclusion_proof(index, size);
+    CHECK(*proof == *reference.path(static_cast<size_t>(index)));
+    CHECK(proof->verify(expected_root));
+  }
+
+  if (size > 1)
+  {
+    const uint64_t first_size = size / 2;
+    const auto proof = engine.consistency_proof(first_size, size);
+    CHECK(ProofEngine::verify_consistency(
+      first_size,
+      size,
+      *reference.past_root(static_cast<size_t>(first_size - 1)),
+      expected_root,
+      proof));
+  }
+
+  if (size == SMALL_LEVEL2_SIZE)
+  {
+    CHECK(stats.full_written == SMALL_LEVEL2_TILE_COUNT);
+    CHECK(store.has_full_tile(2, 0));
+    CHECK_FALSE(store.has_full_tile(3, 0));
+    const auto level2 = store.read_tile(TileRef{2, 0});
+    CHECK(level2.size() == SmallStore::TILE_WIDTH);
+  }
+}
+
+TEST_CASE("Compile-time tile geometry isolates storage formats")
+{
+  const TemporaryDirectory temporary_directory;
+  const fs::path& prefix = temporary_directory.path();
+  const merkle::tiles::TileStore default_store(prefix);
+  SmallStore small_store(prefix);
+
+  CHECK(
+    default_store.root().lexically_relative(prefix).generic_string() ==
+    "sha256-256w");
+  CHECK(
+    small_store.root().lexically_relative(prefix).generic_string() ==
+    "sha256-4w");
+  CHECK(default_store.root() != small_store.root());
+
+  const auto full = make_hashes(SmallStore::TILE_WIDTH);
+  small_store.write_tile(TileRef{0, 0}, full);
+  CHECK(small_store.has_full_tile(0, 0));
+  CHECK(small_store.read_tile(TileRef{0, 0}) == full);
+  CHECK(
+    fs::file_size(small_store.tile_path(TileRef{0, 0})) ==
+    SmallStore::TILE_WIDTH * Hash::size_bytes);
+  CHECK_FALSE(default_store.has_full_tile(0, 0));
+
+  const std::vector<Hash> wrong_width(full.begin(), full.end() - 1);
+  CHECK_THROWS_AS(
+    (small_store.write_tile(TileRef{0, 1}, wrong_width)),
+    std::runtime_error);
+}
+
+TEST_CASE("Alternate geometry writes and resolves every tile level")
+{
+  const TemporaryDirectory temporary_directory;
+  const auto hashes = make_hashes(SMALL_LEVEL2_SIZE + 1);
+
+  for (const uint64_t size :
+       {SmallStore::TILE_WIDTH - 1,
+        SmallStore::TILE_WIDTH,
+        SmallStore::TILE_WIDTH + 1,
+        SMALL_LEVEL1_SIZE,
+        SMALL_LEVEL1_SIZE + 1,
+        SMALL_LEVEL2_SIZE,
+        SMALL_LEVEL2_SIZE + 1})
+  {
+    CAPTURE(size);
+    check_proofs(
+      temporary_directory.path() / ("n" + std::to_string(size)), size, hashes);
+  }
+}
+
+TEST_CASE("Alternate geometry controls entry bundle boundaries and recovery")
+{
+  const TemporaryDirectory temporary_directory;
+  SmallStore store(temporary_directory.path());
+  SmallEntryBundleWriter writer(store);
+  const auto hashes = make_hashes(10);
+  const auto entry_at = [&](uint64_t index) -> std::vector<uint8_t> {
+    return hashes[index];
+  };
+
+  CHECK(writer.write_up_to(10, entry_at).full_written == 2);
+  CHECK(store.has_entry_bundle(0));
+  CHECK(store.has_entry_bundle(1));
+  CHECK_FALSE(store.has_entry_bundle(2));
+  CHECK(store.read_entry_bundle(0).size() == SmallStore::TILE_WIDTH);
+
+  overwrite_file(store.entries_path(0));
+  CHECK_FALSE(store.has_entry_bundle(0));
+  SmallEntryBundleWriter resumed(store);
+  CHECK(resumed.write_up_to(10, entry_at).full_written == 1);
+  CHECK(store.has_entry_bundle(0));
+  CHECK(store.has_entry_bundle(1));
+
+  const std::vector<std::vector<uint8_t>> wrong_width(
+    SmallStore::TILE_WIDTH - 1, {0x42});
+  CHECK_THROWS_AS(
+    (store.write_entry_bundle(3, wrong_width)), std::runtime_error);
+}
+
+TEST_CASE("Alternate geometry drives tiled tree lifecycle boundaries")
+{
+  const TemporaryDirectory temporary_directory;
+  const auto hashes = make_hashes(15);
+  SmallTiledTree::Config config;
+  config.prefix = temporary_directory.path() / "tree";
+  config.retention_margin = 5;
+  config.compact_on_flush = true;
+  SmallTiledTree tree(config);
+  merkle::Tree reference;
+
+  for (const auto& hash : hashes)
+  {
+    tree.append(hash);
+    reference.insert(hash);
+  }
+
+  CHECK(tree.flush().full_written == 3);
+  CHECK(tree.flushed_size() == 12);
+  CHECK(tree.immutable_size() == 12);
+  CHECK(tree.tree_ref().min_index() == 4);
+  CHECK(tree.root() == reference.root());
+  CHECK(*tree.inclusion_proof(0, tree.size()) == *reference.path(0));
+  CHECK_THROWS_AS(tree.retract_to(10), std::runtime_error);
+  CHECK_NOTHROW(tree.retract_to(11));
+  CHECK(tree.size() == 12);
+}
+
+TEST_CASE("Alternate geometry preserves interrupted flush seals")
+{
+  const TemporaryDirectory temporary_directory;
+  const auto hashes = make_hashes(8);
+  SmallTiledTree::Config config;
+  config.prefix = temporary_directory.path() / "interrupted";
+  SmallTiledTree tree(config);
+  for (const auto& hash : hashes)
+  {
+    tree.append(hash);
+  }
+
+  const fs::path blocker = tree.store_ref().tile_path(TileRef{0, 1});
+  fs::create_directories(blocker);
+  CHECK_THROWS_AS(tree.flush(), std::runtime_error);
+  CHECK(tree.store_ref().has_full_tile(0, 0));
+  CHECK(tree.flushed_size() == 0);
+  CHECK(tree.immutable_size() == 8);
+  CHECK_THROWS_AS(tree.retract_to(0), std::runtime_error);
+
+  fs::remove(blocker);
+  CHECK(tree.flush().full_written == 1);
+  CHECK(tree.flushed_size() == 8);
+  CHECK(tree.immutable_size() == 8);
+}

--- a/test/tiles_hashes.cpp
+++ b/test/tiles_hashes.cpp
@@ -29,7 +29,9 @@ template <
   typename ProofEngine>
 static void exercise_tiled_hash(const fs::path& prefix, const std::string& name)
 {
-  const auto hashes = make_hashesT<HASH_SIZE>(300);
+  const size_t tile_width = TiledTree::TILE_WIDTH;
+  const size_t frontier_size = tile_width > 44 ? 44 : tile_width - 1;
+  const auto hashes = make_hashesT<HASH_SIZE>(tile_width + frontier_size);
   Tree reference;
   typename TiledTree::Config config;
   config.prefix = prefix;
@@ -43,22 +45,22 @@ static void exercise_tiled_hash(const fs::path& prefix, const std::string& name)
   }
 
   expect(tree.flush().full_written == 1, name + " full tile written");
-  expect(tree.flushed_size() == 256, name + " flushed size");
+  expect(tree.flushed_size() == tile_width, name + " flushed size");
   expect(tree.root() == reference.root(), name + " root");
   expect(
     fs::file_size(tree.store_ref().root() / "tile" / "0" / "000") ==
-      (uintmax_t)merkle::tiles::TILE_WIDTH * HASH_SIZE,
+      (uintmax_t)tile_width * HASH_SIZE,
     name + " tile byte size");
 
   const auto inclusion = tree.inclusion_proof(0, tree.size());
   expect(inclusion->verify(reference.root()), name + " inclusion proof");
 
-  const auto consistency = tree.consistency_proof(256, tree.size());
+  const auto consistency = tree.consistency_proof(tile_width, tree.size());
   expect(
     ProofEngine::verify_consistency(
-      256,
+      tile_width,
       tree.size(),
-      *reference.past_root(255),
+      *reference.past_root(tile_width - 1),
       reference.root(),
       consistency),
     name + " consistency proof");
@@ -81,6 +83,12 @@ int main()
       merkle::Tree512,
       merkle::tiles::TiledTree512,
       merkle::tiles::ProofEngine512>(base / "sha512", "SHA512");
+    exercise_tiled_hash<
+      48,
+      merkle::Tree384,
+      merkle::tiles::TiledTreeT<48, merkle::sha384_openssl, 2>,
+      merkle::tiles::ProofEngine384>(
+      base / "sha384-small", "SHA384 alternate geometry");
 
     std::cout << "tiles_hashes: OK" << '\n';
   }

--- a/test/tiles_level2.cpp
+++ b/test/tiles_level2.cpp
@@ -22,11 +22,11 @@
 
 namespace fs = std::filesystem;
 using merkle::Hash;
-using merkle::tiles::TILE_WIDTH;
 using merkle::tiles::TileHashSource;
 using merkle::tiles::TileRef;
 using merkle::tiles::TileStore;
 using merkle::tiles::TileWriter;
+static constexpr size_t TILE_WIDTH = TileStore::TILE_WIDTH;
 
 static void expect(bool cond, const std::string& what)
 {

--- a/test/tiles_proofs.cpp
+++ b/test/tiles_proofs.cpp
@@ -21,10 +21,10 @@ using merkle::Hash;
 using merkle::tiles::CombinedHashSource;
 using merkle::tiles::MemoryHashSource;
 using merkle::tiles::ProofEngine;
-using merkle::tiles::TILE_WIDTH;
 using merkle::tiles::TileHashSource;
 using merkle::tiles::TileStore;
 using merkle::tiles::TileWriter;
+static constexpr size_t TILE_WIDTH = TileStore::TILE_WIDTH;
 
 class ProofEngineProbe : public ProofEngine
 {

--- a/test/tiles_store.cpp
+++ b/test/tiles_store.cpp
@@ -407,7 +407,7 @@ TEST_CASE("Tile writer retries ancestor sync before publication")
   const auto fault = std::make_shared<SyncFault>();
   fault->fail_path = prefix;
   fault->failures_remaining = 1;
-  const auto full = make_hashes(decltype(store)::TILE_WIDTH);
+  const auto full = make_hashes(merkle::tiles::TileStore::TILE_WIDTH);
   const auto leaf_at = [&](uint64_t i) -> const Hash& { return full[i]; };
 
   {

--- a/test/tiles_store.cpp
+++ b/test/tiles_store.cpp
@@ -134,7 +134,8 @@ static std::vector<uint8_t> read_file(const fs::path& p)
 
 static std::vector<std::vector<uint8_t>> make_entries()
 {
-  std::vector<std::vector<uint8_t>> entries(merkle::tiles::TILE_WIDTH);
+  std::vector<std::vector<uint8_t>> entries(
+    merkle::tiles::TileStore::TILE_WIDTH);
   entries[1] = {0xA5};
   entries[2] = std::vector<uint8_t>(256, 0x5A);
   for (size_t i = 3; i < entries.size(); i++)
@@ -147,7 +148,9 @@ static std::vector<std::vector<uint8_t>> make_entries()
 TEST_CASE("Tile geometry, references, and index encoding")
 {
   // 1. Tile geometry, references, and index encoding.
-  CHECK(merkle::tiles::TILE_WIDTH == (1U << merkle::tiles::TILE_HEIGHT));
+  CHECK(
+    merkle::tiles::TileStore::TILE_WIDTH ==
+    (1U << merkle::tiles::TileStore::TILE_HEIGHT));
 
   const TileRef default_ref;
   CHECK(default_ref.level == 0);
@@ -251,13 +254,13 @@ TEST_CASE("Tile store paths and hash namespaces")
   }
   TileStore384 store384(dir);
   const auto full384 =
-    make_hashesT<merkle::Tree384::Hash::size_bytes>(merkle::tiles::TILE_WIDTH);
+    make_hashesT<merkle::Tree384::Hash::size_bytes>(TileStore384::TILE_WIDTH);
   CHECK(
     store384.root().lexically_relative(dir).generic_string() == "sha384-256w");
   store384.write_tile(TileRef{0, 0}, full384);
   CHECK(
     fs::file_size(store384.tile_path(TileRef{0, 0})) ==
-    (uintmax_t)merkle::tiles::TILE_WIDTH * merkle::Tree384::Hash::size_bytes);
+    (uintmax_t)TileStore384::TILE_WIDTH * merkle::Tree384::Hash::size_bytes);
   CHECK(store384.has_full_tile(0, 0));
   CHECK(store384.read_tile(TileRef{0, 0}) == full384);
 
@@ -271,13 +274,13 @@ TEST_CASE("Tile store paths and hash namespaces")
   }
   TileStore512 store512(dir);
   const auto full512 =
-    make_hashesT<merkle::Tree512::Hash::size_bytes>(merkle::tiles::TILE_WIDTH);
+    make_hashesT<merkle::Tree512::Hash::size_bytes>(TileStore512::TILE_WIDTH);
   CHECK(
     store512.root().lexically_relative(dir).generic_string() == "sha512-256w");
   store512.write_tile(TileRef{0, 0}, full512);
   CHECK(
     fs::file_size(store512.tile_path(TileRef{0, 0})) ==
-    (uintmax_t)merkle::tiles::TILE_WIDTH * merkle::Tree512::Hash::size_bytes);
+    (uintmax_t)TileStore512::TILE_WIDTH * merkle::Tree512::Hash::size_bytes);
   CHECK(store512.has_full_tile(0, 0));
   CHECK(store512.read_tile(TileRef{0, 0}) == full512);
 #endif
@@ -292,7 +295,7 @@ TEST_CASE("Tile writes sync directory links in order")
   const fs::path prefix = dir / "durable";
   const auto fault = std::make_shared<SyncFault>();
   FaultInjectingTileStore store(prefix, fault);
-  store.write_tile(TileRef{1, 0}, make_hashes(merkle::tiles::TILE_WIDTH));
+  store.write_tile(TileRef{1, 0}, make_hashes(decltype(store)::TILE_WIDTH));
 
   const std::vector<fs::path> expected = {
     dir.parent_path(),
@@ -319,7 +322,7 @@ TEST_CASE("Failed directory-link sync is retried")
   fault->failures_remaining = 1;
   FaultInjectingTileStore store(prefix, fault);
   const TileRef ref{2, 7};
-  const auto full = make_hashes(merkle::tiles::TILE_WIDTH);
+  const auto full = make_hashes(decltype(store)::TILE_WIDTH);
 
   CHECK_THROWS_AS((store.write_tile(ref, full)), std::runtime_error);
   CHECK_FALSE(store.has_full_tile(ref.level, ref.index));
@@ -337,7 +340,7 @@ TEST_CASE("Visible publication can be confirmed after sync failure")
   const auto fault = std::make_shared<SyncFault>();
   FaultInjectingTileStore store(prefix, fault);
   const TileRef ref{3, 9};
-  const auto full = make_hashes(merkle::tiles::TILE_WIDTH);
+  const auto full = make_hashes(decltype(store)::TILE_WIDTH);
   const auto tile_directory = store.tile_path(ref).parent_path();
   fault->fail_path = tile_directory;
   fault->failures_remaining = 1;
@@ -365,7 +368,7 @@ TEST_CASE("Tile writer confirms visible tiles after sync failure")
     temporary_directory.path() / "writer_publication_retry";
   const auto fault = std::make_shared<SyncFault>();
   constexpr uint64_t growing_size =
-    (uint64_t)merkle::tiles::TILE_WIDTH * 2;
+    (uint64_t)merkle::tiles::TileStore::TILE_WIDTH * 2;
   const auto growing = make_hashes((size_t)growing_size);
   const auto leaf_at = [&](uint64_t i) -> const Hash& { return growing[i]; };
 
@@ -375,7 +378,8 @@ TEST_CASE("Tile writer confirms visible tiles after sync failure")
     retry_store.tile_path(TileRef{0, 0}).parent_path();
   fault->fail_path = destination;
   REQUIRE(
-    retry_writer.write_up_to(merkle::tiles::TILE_WIDTH, leaf_at).full_written ==
+    retry_writer.write_up_to(
+      merkle::tiles::TileStore::TILE_WIDTH, leaf_at).full_written ==
     1);
 
   fault->matching_calls_before_failure = 1;
@@ -391,7 +395,8 @@ TEST_CASE("Tile writer confirms visible tiles after sync failure")
   CHECK(retry_writer.write_up_to(growing_size, leaf_at).full_written == 0);
   CHECK(fault->call_count(destination) == 4);
   const std::vector<Hash> second(
-    growing.begin() + (std::ptrdiff_t)merkle::tiles::TILE_WIDTH, growing.end());
+    growing.begin() + (std::ptrdiff_t)merkle::tiles::TileStore::TILE_WIDTH,
+    growing.end());
   CHECK(retry_store.read_tile(TileRef{0, 1}) == second);
 }
 
@@ -402,14 +407,15 @@ TEST_CASE("Tile writer retries ancestor sync before publication")
   const auto fault = std::make_shared<SyncFault>();
   fault->fail_path = prefix;
   fault->failures_remaining = 1;
-  const auto full = make_hashes(merkle::tiles::TILE_WIDTH);
+  const auto full = make_hashes(decltype(store)::TILE_WIDTH);
   const auto leaf_at = [&](uint64_t i) -> const Hash& { return full[i]; };
 
   {
     FaultInjectingTileStore failed_store(prefix, fault);
     merkle::tiles::TileWriter writer(failed_store);
     CHECK_THROWS_AS(
-      (writer.write_up_to(merkle::tiles::TILE_WIDTH, leaf_at)),
+      (writer.write_up_to(
+        merkle::tiles::TileStore::TILE_WIDTH, leaf_at)),
       std::runtime_error);
     CHECK(fs::is_directory(prefix / "sha256-256w"));
     CHECK_FALSE(failed_store.has_full_tile(0, 0));
@@ -418,7 +424,8 @@ TEST_CASE("Tile writer retries ancestor sync before publication")
   FaultInjectingTileStore retry_store(prefix, fault);
   merkle::tiles::TileWriter retry_writer(retry_store);
   CHECK(
-    retry_writer.write_up_to(merkle::tiles::TILE_WIDTH, leaf_at).full_written ==
+    retry_writer.write_up_to(
+      merkle::tiles::TileStore::TILE_WIDTH, leaf_at).full_written ==
     1);
   CHECK(fault->call_count(prefix) == 2);
   CHECK(retry_store.has_full_tile(0, 0));
@@ -430,7 +437,7 @@ TEST_CASE("Replacement and directory conflicts clean up temporary files")
   // non-directory in the destination path is rejected.
   const TemporaryDirectory temporary_directory;
   const fs::path& dir = temporary_directory.path();
-  const auto full = make_hashes(merkle::tiles::TILE_WIDTH);
+  const auto full = make_hashes(merkle::tiles::TileStore::TILE_WIDTH);
 
   const fs::path replacement_prefix = dir / "replacement_failure";
   merkle::tiles::TileStore replacement_store(replacement_prefix);
@@ -531,7 +538,7 @@ TEST_CASE("Full tiles use raw bytes and round-trip")
   const TemporaryDirectory temporary_directory;
   merkle::tiles::TileStore store(temporary_directory.path());
   const size_t hash_size = Hash().size();
-  const auto full = make_hashes(merkle::tiles::TILE_WIDTH);
+  const auto full = make_hashes(decltype(store)::TILE_WIDTH);
   const TileRef full_ref{0, 0};
 
   store.write_tile(full_ref, full);
@@ -540,7 +547,7 @@ TEST_CASE("Full tiles use raw bytes and round-trip")
   CHECK_THROWS_AS((void)store.read_tile(TileRef{0, 5}), std::runtime_error);
   CHECK(
     fs::file_size(store.tile_path(full_ref)) ==
-    (uintmax_t)merkle::tiles::TILE_WIDTH * hash_size);
+    (uintmax_t)decltype(store)::TILE_WIDTH * hash_size);
 
   std::vector<uint8_t> expected_tile_bytes;
   expected_tile_bytes.reserve(full.size() * hash_size);
@@ -580,7 +587,7 @@ TEST_CASE("Entry encoding enforces bounds and round-trips")
   CHECK(encoded_entries[6] == 0x00);
   CHECK(
     merkle::tiles::TileStore::decode_entries(
-      encoded_entries, merkle::tiles::TILE_WIDTH) == entries);
+      encoded_entries, merkle::tiles::TileStore::TILE_WIDTH) == entries);
   CHECK(merkle::tiles::TileStore::decode_entries({}, 0).empty());
   CHECK_THROWS_AS(
     (merkle::tiles::TileStore::decode_entries(
@@ -652,7 +659,7 @@ TEST_CASE("Corrupt tiles and entry bundles are rejected")
   const TemporaryDirectory temporary_directory;
   merkle::tiles::TileStore store(temporary_directory.path());
   const size_t hash_size = Hash().size();
-  const auto full = make_hashes(merkle::tiles::TILE_WIDTH);
+  const auto full = make_hashes(decltype(store)::TILE_WIDTH);
   const TileRef full_ref{0, 0};
   const auto entries = make_entries();
   store.write_tile(full_ref, full);
@@ -662,7 +669,7 @@ TEST_CASE("Corrupt tiles and entry bundles are rejected")
   const auto short_tile_error = std::format(
     "unexpected tile size for {}: expected {} bytes, got {}",
     store.tile_path(full_ref).string(),
-    merkle::tiles::TILE_WIDTH * hash_size,
+    decltype(store)::TILE_WIDTH * hash_size,
     hash_size);
   CHECK_THROWS_WITH_AS(
     (void)store.read_tile(full_ref),
@@ -674,7 +681,7 @@ TEST_CASE("Corrupt tiles and entry bundles are rejected")
 
   overwrite_file(
     store.tile_path(full_ref),
-    std::vector<uint8_t>((merkle::tiles::TILE_WIDTH + 1) * hash_size, 0));
+    std::vector<uint8_t>((decltype(store)::TILE_WIDTH + 1) * hash_size, 0));
   CHECK_FALSE(store.has_full_tile(0, 0));
   CHECK_THROWS_AS((void)store.read_tile(full_ref), std::runtime_error);
 

--- a/test/tiles_tree.cpp
+++ b/test/tiles_tree.cpp
@@ -766,7 +766,7 @@ int main()
       // Here all 256 level-0 tiles publish before the level-1 tile is blocked.
       {
         constexpr size_t level1_size =
-          (size_t)merkle::tiles::TILE_WIDTH * merkle::tiles::TILE_WIDTH;
+          (size_t)TileStore::TILE_WIDTH * TileStore::TILE_WIDTH;
         const auto level1_hashes = make_hashes(level1_size);
 
         TiledTree::Config cfg;

--- a/test/tiles_writer.cpp
+++ b/test/tiles_writer.cpp
@@ -284,8 +284,8 @@ int main()
         writer.write_up_to(2048, leaf_at).full_written == 1,
         "F rewrites interior hole");
       const std::vector<Hash> expected(
-        hashes.begin() + (std::ptrdiff_t)merkle::tiles::TILE_WIDTH * 3,
-        hashes.begin() + (std::ptrdiff_t)merkle::tiles::TILE_WIDTH * 4);
+        hashes.begin() + (std::ptrdiff_t)TileStore::TILE_WIDTH * 3,
+        hashes.begin() + (std::ptrdiff_t)TileStore::TILE_WIDTH * 4);
       expect(
         store.read_tile(TileRef{0, 3}) == expected, "F repaired tile contents");
       expect(tile_file_count(store) == 8, "F exact tile file count");
@@ -297,7 +297,7 @@ int main()
     // at geometrically increasing indices cannot overflow its search.
     {
       const fs::path dir = base / "g";
-      const auto hashes = make_hashes(merkle::tiles::TILE_WIDTH);
+      const auto hashes = make_hashes(TileStore::TILE_WIDTH);
       {
         TileStore store(dir);
         store.write_tile(TileRef{0, 0}, hashes);
@@ -315,7 +315,7 @@ int main()
       TileWriter writer(store);
       const auto leaf_at = [&](uint64_t i) -> const Hash& { return hashes[i]; };
       expect(
-        writer.write_up_to(merkle::tiles::TILE_WIDTH, leaf_at).full_written ==
+        writer.write_up_to(TileStore::TILE_WIDTH, leaf_at).full_written ==
           0,
         "G bounded sparse recovery");
       expect(store.has_full_tile(0, 0), "G requested tile remains valid");
@@ -329,11 +329,11 @@ int main()
     {
       const fs::path dir = base / "h";
       TileStore store(dir);
-      const auto child_template = make_hashes(merkle::tiles::TILE_WIDTH);
+      const auto child_template = make_hashes(TileStore::TILE_WIDTH);
       std::vector<Hash> expected;
-      expected.reserve(merkle::tiles::TILE_WIDTH);
+      expected.reserve(TileStore::TILE_WIDTH);
 
-      for (uint64_t index = 0; index < merkle::tiles::TILE_WIDTH; index++)
+      for (uint64_t index = 0; index < TileStore::TILE_WIDTH; index++)
       {
         auto child = child_template;
         child[0].bytes[0] = static_cast<uint8_t>(index);
@@ -344,8 +344,8 @@ int main()
       TileWriterProbe writer(store);
       writer.mark_level_complete(
         0,
-        (uint64_t)merkle::tiles::TILE_WIDTH * merkle::tiles::TILE_WIDTH);
-      writer.mark_level_complete(1, merkle::tiles::TILE_WIDTH);
+        (uint64_t)TileStore::TILE_WIDTH * TileStore::TILE_WIDTH);
+      writer.mark_level_complete(1, TileStore::TILE_WIDTH);
 
       bool leaf_requested = false;
       const Hash unused;
@@ -353,8 +353,8 @@ int main()
         leaf_requested = true;
         return unused;
       };
-      constexpr uint64_t size = (uint64_t)merkle::tiles::TILE_WIDTH *
-        merkle::tiles::TILE_WIDTH * merkle::tiles::TILE_WIDTH;
+      constexpr uint64_t size = (uint64_t)TileStore::TILE_WIDTH *
+        TileStore::TILE_WIDTH * TileStore::TILE_WIDTH;
       const auto stats = writer.write_up_to(size, leaf_at);
 
       expect(stats.full_written == 1, "H writes one L2 tile");
@@ -379,8 +379,8 @@ int main()
         Hash384::size_bytes,
         merkle::Tree384::hash_function>;
 
-      constexpr uint64_t size = (uint64_t)merkle::tiles::TILE_WIDTH *
-        merkle::tiles::TILE_WIDTH;
+      constexpr uint64_t size =
+        (uint64_t)TileStore384::TILE_WIDTH * TileStore384::TILE_WIDTH;
       const auto hashes = make_hashesT<Hash384::size_bytes>((size_t)size);
       const auto leaf_at = [&](uint64_t index) -> const Hash384& {
         return hashes[index];
@@ -394,7 +394,7 @@ int main()
       expect(store.has_full_tile(1, 0), "I full SHA-384 L1 tile");
       const auto level1 = store.read_tile(TileRef{1, 0});
       const std::vector<Hash384> first_tile(
-        hashes.begin(), hashes.begin() + merkle::tiles::TILE_WIDTH);
+        hashes.begin(), hashes.begin() + TileStore384::TILE_WIDTH);
       expect(
         level1[0] ==
           merkle::tiles::perfect_root<

--- a/tools/proof-viz/app.js
+++ b/tools/proof-viz/app.js
@@ -12,6 +12,10 @@ const scenarioRoot = document.querySelector("#scenarios");
     if (data.schemaVersion !== 5 || !Array.isArray(data.scenarios)) {
         throw new Error("Proof visualization data is missing");
     }
+    const tileHeight = Math.log2(data.tileWidth);
+    if (!Number.isInteger(tileHeight)) {
+        throw new Error("Tile width must be a power of two");
+    }
 
     // Nodes arrive as parallel columns with one bitmask each. The tile and
     // frontier bits are what those two stores answered for that range, so a
@@ -197,6 +201,31 @@ const scenarioRoot = document.querySelector("#scenarios");
                 x: plot.left + (((node.lo + node.hi) / 2) / scenario.mapLeaves) * plotWidth,
                 y: plot.top + ((maxHeight - node.height) / Math.max(maxHeight, 1)) * plotHeight
             }));
+
+            scenario.tiles.forEach(([level, index]) => {
+                const tileSpan = data.tileWidth ** (level + 1);
+                const lo = index * tileSpan;
+                const hi = lo + tileSpan;
+                if (hi > scenario.mapLeaves) return;
+
+                const x = plot.left + (lo / scenario.mapLeaves) * plotWidth;
+                const right = plot.left + (hi / scenario.mapLeaves) * plotWidth;
+                const y = plot.top +
+                    ((maxHeight - level * tileHeight) / Math.max(maxHeight, 1)) * plotHeight;
+                const inset = 2;
+                const boxHeight = 14;
+                context.save();
+                context.setLineDash([4, 3]);
+                context.strokeStyle = colors.tile;
+                context.lineWidth = 1;
+                context.strokeRect(
+                    snap(x + inset),
+                    snap(y - boxHeight / 2),
+                    snap(right - x - inset * 2),
+                    boxHeight
+                );
+                context.restore();
+            });
 
             if (scenario.covered > 0 && scenario.covered < scenario.mapLeaves) {
                 const boundaryX = plot.left + (scenario.covered / scenario.mapLeaves) * plotWidth;

--- a/tools/proof-viz/app.js
+++ b/tools/proof-viz/app.js
@@ -257,7 +257,7 @@ const scenarioRoot = document.querySelector("#scenarios");
                     Math.max(0, scenario.mapLeaves - scenario.covered);
                 const routeOutsideTree =
                     visibleFrontier > 0 &&
-                    visibleFrontier < data.tileWidth / 2 &&
+                    visibleFrontier <= data.tileWidth / 2 &&
                     scenario.tiles.length >= data.tileWidth;
                 context.lineWidth = 0.7;
                 context.strokeStyle = colors.edge;

--- a/tools/proof-viz/app.js
+++ b/tools/proof-viz/app.js
@@ -83,11 +83,14 @@ const scenarioRoot = document.querySelector("#scenarios");
     const tooltip = document.querySelector("#node-tooltip");
     const renderers = [];
 
-    window.matchMedia("(prefers-color-scheme: dark)").addEventListener(
+    const systemDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
+    systemDarkTheme.addEventListener(
         "change",
         (event) => {
-            if (!localStorage.getItem("theme")) {
+            if (!localStorage.getItem("proof-viz-theme")) {
                 document.documentElement.dataset.theme = event.matches ? "dark" : "light";
+                const themeToggle = document.querySelector("#toggle-theme");
+                if (themeToggle) themeToggle.checked = event.matches;
             }
             colors = readCanvasColors();
             renderers.forEach((renderer) => renderer.draw());
@@ -215,9 +218,8 @@ const scenarioRoot = document.querySelector("#scenarios");
                 const inset = 2;
                 const boxHeight = 14;
                 context.save();
-                context.setLineDash([4, 3]);
                 context.strokeStyle = colors.tile;
-                context.lineWidth = 1;
+                context.lineWidth = 0.65;
                 context.strokeRect(
                     snap(x + inset),
                     snap(y - boxHeight / 2),
@@ -280,13 +282,11 @@ const scenarioRoot = document.querySelector("#scenarios");
                 context.restore();
             }
 
-            // Tile and frontier squares are the densest thing on the canvas.
-            // Two physical pixels reads clearly and still leaves a gap beside
-            // each leaf once there are three pixels to place them in; below
-            // that the row fuses into a bar, so it falls back to the smallest
-            // mark a screen can draw.
-            const pitch = (plotWidth * pixelRatio) / scenario.mapLeaves;
-            const baseSize = devicePx * (pitch >= 3 ? 2 : 1);
+            // Scale marks with the available leaf spacing. The small atlas
+            // scenarios can carry clearer nodes, while the cap preserves gaps
+            // in denser rows.
+            const pitch = plotWidth / scenario.mapLeaves;
+            const baseSize = Math.max(devicePx * 2, Math.min(4, pitch * 0.36));
             hitTargets = [];
             scenario.nodes.forEach((node, index) => {
                 const position = positions[index];
@@ -529,6 +529,16 @@ const scenarioRoot = document.querySelector("#scenarios");
 
     document.querySelector("#toggle-edges").addEventListener("change", (event) => {
         state.edges = event.target.checked;
+        renderers.forEach((renderer) => renderer.draw());
+    });
+
+    const themeToggle = document.querySelector("#toggle-theme");
+    themeToggle.checked = document.documentElement.dataset.theme === "dark";
+    themeToggle.addEventListener("change", (event) => {
+        const theme = event.target.checked ? "dark" : "light";
+        document.documentElement.dataset.theme = theme;
+        localStorage.setItem("proof-viz-theme", theme);
+        colors = readCanvasColors();
         renderers.forEach((renderer) => renderer.draw());
     });
 

--- a/tools/proof-viz/app.js
+++ b/tools/proof-viz/app.js
@@ -82,18 +82,21 @@ const scenarioRoot = document.querySelector("#scenarios");
     const number = new Intl.NumberFormat("en-US");
     const tooltip = document.querySelector("#node-tooltip");
     const renderers = [];
+    const themeToggle = document.querySelector("#toggle-theme");
+    const applyTheme = (theme) => {
+        document.documentElement.dataset.theme = theme;
+        themeToggle.checked = theme === "dark";
+        colors = readCanvasColors();
+        renderers.forEach((renderer) => renderer.draw());
+    };
 
     const systemDarkTheme = window.matchMedia("(prefers-color-scheme: dark)");
     systemDarkTheme.addEventListener(
         "change",
         (event) => {
             if (!localStorage.getItem("proof-viz-theme")) {
-                document.documentElement.dataset.theme = event.matches ? "dark" : "light";
-                const themeToggle = document.querySelector("#toggle-theme");
-                if (themeToggle) themeToggle.checked = event.matches;
+                applyTheme(event.matches ? "dark" : "light");
             }
-            colors = readCanvasColors();
-            renderers.forEach((renderer) => renderer.draw());
         }
     );
 
@@ -250,6 +253,12 @@ const scenarioRoot = document.querySelector("#scenarios");
             }
 
             if (state.edges) {
+                const visibleFrontier =
+                    Math.max(0, scenario.mapLeaves - scenario.covered);
+                const routeOutsideTree =
+                    visibleFrontier > 0 &&
+                    visibleFrontier < data.tileWidth / 2 &&
+                    scenario.tiles.length >= data.tileWidth;
                 context.lineWidth = 0.7;
                 context.strokeStyle = colors.edge;
                 context.beginPath();
@@ -258,7 +267,25 @@ const scenarioRoot = document.querySelector("#scenarios");
                     const parent = positions[node.parent];
                     const current = positions[index];
                     context.moveTo(parent.x, parent.y);
-                    context.lineTo(current.x, current.y);
+                    const parentNode = scenario.nodes[node.parent];
+                    const longBoundaryEdge =
+                        routeOutsideTree &&
+                        node.parent === scenario.secondRoot &&
+                        parentNode.height - node.height > 1 &&
+                        (node.lo === 0 || node.hi === scenario.mapLeaves);
+                    if (longBoundaryEdge) {
+                        const gutterX = node.lo === 0 ? 8 : cssWidth - 8;
+                        context.bezierCurveTo(
+                            gutterX,
+                            parent.y,
+                            gutterX,
+                            current.y,
+                            current.x,
+                            current.y
+                        );
+                    } else {
+                        context.lineTo(current.x, current.y);
+                    }
                 });
                 context.stroke();
 
@@ -532,14 +559,11 @@ const scenarioRoot = document.querySelector("#scenarios");
         renderers.forEach((renderer) => renderer.draw());
     });
 
-    const themeToggle = document.querySelector("#toggle-theme");
     themeToggle.checked = document.documentElement.dataset.theme === "dark";
     themeToggle.addEventListener("change", (event) => {
         const theme = event.target.checked ? "dark" : "light";
-        document.documentElement.dataset.theme = theme;
         localStorage.setItem("proof-viz-theme", theme);
-        colors = readCanvasColors();
-        renderers.forEach((renderer) => renderer.draw());
+        applyTheme(theme);
     });
 
 })().catch((error) => {

--- a/tools/proof-viz/index.html
+++ b/tools/proof-viz/index.html
@@ -27,7 +27,7 @@
             </div>
             <p class="masthead__stats" aria-label="Atlas summary">
                 <span><b id="scene-count">11</b> scenes</span>
-                <span><b id="tile-width">256</b> tile width</span>
+                <span><b id="tile-width">8</b> tile width</span>
                 <span><b>Live calls</b> evidence</span>
             </p>
         </div>

--- a/tools/proof-viz/index.html
+++ b/tools/proof-viz/index.html
@@ -55,6 +55,7 @@
         <section class="legend-band" aria-label="Node colors">
             <ul class="legend">
                 <li><span class="swatch swatch--tile"></span><b>Tile</b> durable full-tile data</li>
+                <li><span class="swatch swatch--tile-file"></span><b>Tile file</b> dashed enclosure</li>
                 <li><span class="swatch swatch--frontier"></span><b>Frontier</b> resident in-memory data</li>
                 <li><span class="swatch swatch--proof"></span><b>Proof element</b> returned in the proof</li>
                 <li><span class="swatch swatch--spine"></span><b>Ringed</b> only in the tree ending at A</li>
@@ -66,26 +67,6 @@
             <p class="load-status" role="status">Loading proof data...</p>
         </section>
 
-        <section class="method" aria-labelledby="method-title">
-            <div>
-                <p class="section-label">Method</p>
-                <h2 id="method-title">Observed, not simulated</h2>
-            </div>
-            <div class="method__copy">
-                <p>
-                    Each scene constructs the same production-shaped fixture used by
-                    <code>tiles_proofs</code>: full tiles cover the compacted prefix and
-                    an in-memory tree owns the frontier. The highlighted nodes are the
-                    elements returned by the real <code>ProofEngine</code>.
-                </p>
-                <p>
-                    Inclusion scenes are checked byte-for-byte against
-                    <code>Tree::path()</code>. The consistency scene is verified with
-                    <code>ProofEngine::verify_consistency()</code> before it reaches this
-                    page.
-                </p>
-            </div>
-        </section>
     </main>
 
     <div id="node-tooltip" class="node-tooltip" role="tooltip" hidden></div>

--- a/tools/proof-viz/index.html
+++ b/tools/proof-viz/index.html
@@ -7,8 +7,11 @@
     <meta name="description" content="An instrumented atlas of merklecpp tile-backed inclusion and consistency proofs.">
     <title>Merkle proof atlas</title>
     <script>
-        document.documentElement.dataset.theme = localStorage.getItem("theme") ||
-            (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+        const savedTheme = localStorage.getItem("proof-viz-theme");
+        document.documentElement.dataset.theme =
+            savedTheme === "dark" || savedTheme === "light"
+                ? savedTheme
+                : (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
     </script>
     <link rel="stylesheet" href="styles.css">
     <script src="app.js" defer></script>
@@ -48,6 +51,10 @@
                         <input id="toggle-edges" type="checkbox" checked>
                         Tree edges
                     </label>
+                    <label class="toggle">
+                        <input id="toggle-theme" type="checkbox">
+                        Dark theme
+                    </label>
                 </div>
             </div>
         </section>
@@ -55,7 +62,7 @@
         <section class="legend-band" aria-label="Node colors">
             <ul class="legend">
                 <li><span class="swatch swatch--tile"></span><b>Tile</b> durable full-tile data</li>
-                <li><span class="swatch swatch--tile-file"></span><b>Tile file</b> dashed enclosure</li>
+                <li><span class="swatch swatch--tile-file"></span><b>Tile file</b> thin enclosure</li>
                 <li><span class="swatch swatch--frontier"></span><b>Frontier</b> resident in-memory data</li>
                 <li><span class="swatch swatch--proof"></span><b>Proof element</b> returned in the proof</li>
                 <li><span class="swatch swatch--spine"></span><b>Ringed</b> only in the tree ending at A</li>

--- a/tools/proof-viz/proof_viz.cpp
+++ b/tools/proof-viz/proof_viz.cpp
@@ -28,10 +28,10 @@ using merkle::tiles::HashSource;
 using merkle::tiles::MAX_TILE_LEVEL;
 using merkle::tiles::MemoryHashSource;
 using merkle::tiles::ProofEngine;
-using merkle::tiles::TILE_WIDTH;
 using merkle::tiles::TileHashSource;
 using merkle::tiles::TileStore;
 using merkle::tiles::TileWriter;
+static constexpr size_t TILE_WIDTH = TileStore::TILE_WIDTH;
 
 // Node roles, packed into one integer per node so the JSON stays compact.
 static constexpr uint32_t FLAG_TILE = 1U << 0;

--- a/tools/proof-viz/proof_viz.cpp
+++ b/tools/proof-viz/proof_viz.cpp
@@ -627,18 +627,6 @@ int main(int argc, char** argv)
                 << scenario.proof_nodes.size() << " proof elements, "
                 << scenario.tile_files.size() << " tiles\n";
     }
-    const bool has_level_one_tile =
-      std::any_of(scenarios.begin(), scenarios.end(), [](const Scenario& s) {
-        return std::any_of(
-          s.tile_files.begin(), s.tile_files.end(), [](const auto& tile) {
-            return tile.first == 1;
-          });
-      });
-    if (!has_level_one_tile)
-    {
-      throw std::runtime_error(
-        "proof visualization scenarios must exercise level-1 tiles");
-    }
     write_data(output, scenarios);
     std::cout << "wrote " << output << '\n';
   }

--- a/tools/proof-viz/proof_viz.cpp
+++ b/tools/proof-viz/proof_viz.cpp
@@ -28,9 +28,19 @@ using merkle::tiles::HashSource;
 using merkle::tiles::MAX_TILE_LEVEL;
 using merkle::tiles::MemoryHashSource;
 using merkle::tiles::ProofEngine;
-using merkle::tiles::TileHashSource;
-using merkle::tiles::TileStore;
-using merkle::tiles::TileWriter;
+static constexpr uint8_t TILE_HEIGHT = 3;
+using TileHashSource = merkle::tiles::TileHashSourceT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  TILE_HEIGHT>;
+using TileStore = merkle::tiles::TileStoreT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  TILE_HEIGHT>;
+using TileWriter = merkle::tiles::TileWriterT<
+  Hash::size_bytes,
+  merkle::Tree::hash_function,
+  TILE_HEIGHT>;
 static constexpr size_t TILE_WIDTH = TileStore::TILE_WIDTH;
 
 // Node roles, packed into one integer per node so the JSON stays compact.
@@ -616,6 +626,18 @@ int main(int argc, char** argv)
       std::cout << scenario.id << ": " << scenario.nodes.size() << " nodes, "
                 << scenario.proof_nodes.size() << " proof elements, "
                 << scenario.tile_files.size() << " tiles\n";
+    }
+    const bool has_level_one_tile =
+      std::any_of(scenarios.begin(), scenarios.end(), [](const Scenario& s) {
+        return std::any_of(
+          s.tile_files.begin(), s.tile_files.end(), [](const auto& tile) {
+            return tile.first == 1;
+          });
+      });
+    if (!has_level_one_tile)
+    {
+      throw std::runtime_error(
+        "proof visualization scenarios must exercise level-1 tiles");
     }
     write_data(output, scenarios);
     std::cout << "wrote " << output << '\n';

--- a/tools/proof-viz/scenarios/across-two-tiles.scenario
+++ b/tools/proof-viz/scenarios/across-two-tiles.scenario
@@ -1,9 +1,9 @@
 name: across-two-tiles
 proof: inclusion
-title: A proof across two full tiles
-description: At 544 leaves two tiles are complete and only 32 leaves remain resident. Leaf 100 sits inside the first tile.
-takeaway: Nine of the ten hashes come from tile storage, doubling in width from a single leaf up to the whole second tile, and one 32-leaf frontier range closes the root.
+title: A proof across two tile levels
+description: At 70 leaves, eight level-0 tiles and one level-1 tile cover the first 64 leaves, while 6 leaves remain resident. Leaf 4 sits in the tiled history.
+takeaway: Tile storage supplies the path through the level-0 data and its level-1 roll-up; resident frontier ranges then close the 70-leaf root.
 order: 7
-leaves: 544
-focus: 100
+leaves: 70
+focus: 4
 second: none

--- a/tools/proof-viz/scenarios/boundary-overlap.scenario
+++ b/tools/proof-viz/scenarios/boundary-overlap.scenario
@@ -1,9 +1,9 @@
 name: boundary-overlap
 proof: inclusion
-title: The exact two-tile boundary
-description: At 512 leaves, both tiles are complete. Compaction deliberately retains the final leaf in memory because merklecpp never flushes the entire tree.
+title: The exact level-1 boundary
+description: At 64 leaves, eight level-0 tiles and their level-1 roll-up are complete. Compaction deliberately retains the final leaf in memory because merklecpp never flushes the entire tree.
 takeaway: The blue target pixel has a green overlap mark: both sources can answer it, but CombinedHashSource chooses memory first; its siblings come from tiles.
 order: 5
-leaves: 512
-focus: 511
+leaves: 64
+focus: 63
 second: none

--- a/tools/proof-viz/scenarios/consistency-arbitrary-crossing.scenario
+++ b/tools/proof-viz/scenarios/consistency-arbitrary-crossing.scenario
@@ -1,9 +1,9 @@
 name: consistency-arbitrary-crossing
 proof: consistency
 title: Two unaligned sizes cross the boundary
-description: The 92-leaf tree state is checked as a prefix of the 288-leaf one, inside a 300-leaf backing tree.
-takeaway: Four of the eight returned hashes rebuild the old root and the rest extend it to the new one, so the old size sits wholly in the tiled past while the new size also needs the resident frontier.
+description: The 23-leaf tree state is checked as a prefix of the 68-leaf one, inside a 70-leaf backing tree.
+takeaway: The returned hashes rebuild an unaligned old root from tiled history, then extend it across the level-1 boundary into the resident frontier.
 order: 11
-leaves: 300
-focus: 91
-second: 287
+leaves: 70
+focus: 22
+second: 67

--- a/tools/proof-viz/scenarios/consistency-boundary.scenario
+++ b/tools/proof-viz/scenarios/consistency-boundary.scenario
@@ -1,9 +1,9 @@
 name: consistency-boundary
 proof: consistency
 title: Consistency across the flush line
-description: The 256-leaf tree state is checked as a prefix of the 300-leaf one, on opposite sides of the flush line.
-takeaway: The old tree is exactly the left subtree of the new one, so the proof is a single hash covering the 44 remaining leaves and verifying is one step: sha256 of the old root and that hash.
+description: The 64-leaf tree state is checked as a prefix of the 70-leaf one, on opposite sides of the level-1 flush line.
+takeaway: The old tree is exactly the left subtree of the new one, so the proof is a single hash covering the 6 remaining leaves and verifying is one step: sha256 of the old root and that hash.
 order: 8
-leaves: 300
-focus: 255
-second: 299
+leaves: 70
+focus: 63
+second: 69

--- a/tools/proof-viz/scenarios/consistency-frontier-only.scenario
+++ b/tools/proof-viz/scenarios/consistency-frontier-only.scenario
@@ -1,9 +1,9 @@
 name: consistency-frontier-only
 proof: consistency
 title: Two sizes before tiling
-description: The 48-leaf tree state is checked as a prefix of the 150-leaf one, inside a 192-leaf backing tree that has not completed its first tile.
+description: The 3-leaf tree state is checked as a prefix of the 6-leaf one, inside a 7-leaf backing tree that has not completed its first tile.
 takeaway: Every component is answered by the resident frontier, even though neither size is the backing tree's current one.
 order: 9
-leaves: 192
-focus: 47
-second: 149
+leaves: 7
+focus: 2
+second: 5

--- a/tools/proof-viz/scenarios/consistency-frontier-pair.scenario
+++ b/tools/proof-viz/scenarios/consistency-frontier-pair.scenario
@@ -1,9 +1,9 @@
 name: consistency-frontier-pair
 proof: consistency
 title: Two sizes inside one frontier
-description: The 270-leaf tree state is checked as a prefix of the 494-leaf one, both beyond the first tile in a 511-leaf backing tree.
-takeaway: Both roots include tiled history, but their changing suffixes are assembled from different portions of the same blue frontier.
+description: The 65-leaf tree state is checked as a prefix of the 70-leaf one, both beyond the level-1 boundary in a 71-leaf backing tree.
+takeaway: Both roots include two levels of tiled history, but their changing suffixes are assembled from different portions of the same blue frontier.
 order: 12
-leaves: 511
-focus: 269
-second: 493
+leaves: 71
+focus: 64
+second: 69

--- a/tools/proof-viz/scenarios/consistency-tiled-history.scenario
+++ b/tools/proof-viz/scenarios/consistency-tiled-history.scenario
@@ -1,9 +1,9 @@
 name: consistency-tiled-history
 proof: consistency
 title: Two sizes in tiled history
-description: The 128-leaf tree state is checked as a prefix of the 400-leaf one, both historical inside a 513-leaf backing tree with two durable tiles.
-takeaway: The current frontier begins after both checkpoints, so the complete consistency proof is recovered from green tile storage.
+description: The 16-leaf tree state is checked as a prefix of the 48-leaf one, both historical inside a 65-leaf backing tree with level-0 and level-1 tiles.
+takeaway: The current frontier begins after both checkpoints, so the complete consistency proof is recovered from green storage spanning two tile levels.
 order: 10
-leaves: 513
-focus: 127
-second: 399
+leaves: 65
+focus: 15
+second: 47

--- a/tools/proof-viz/scenarios/frontier-only.scenario
+++ b/tools/proof-viz/scenarios/frontier-only.scenario
@@ -1,9 +1,9 @@
 name: frontier-only
 proof: inclusion
 title: Before the first tile
-description: With 192 leaves, no full 256-entry tile exists. Every subtree request is answered by the resident tree.
+description: With 7 leaves, no full 8-entry tile exists. Every subtree request is answered by the resident tree.
 takeaway: The red route never changes source: the target, proof siblings, and root reduction all stay in the blue frontier.
 order: 1
-leaves: 192
-focus: 37
+leaves: 7
+focus: 3
 second: none

--- a/tools/proof-viz/scenarios/frontier-to-tile.scenario
+++ b/tools/proof-viz/scenarios/frontier-to-tile.scenario
@@ -1,9 +1,9 @@
 name: frontier-to-tile
 proof: inclusion
 title: A frontier proof reaches backward
-description: Leaf 271 sits in the 44-leaf resident frontier beyond one completed tile.
-takeaway: Most local siblings are blue, but the final left sibling is the entire 256-leaf tiled prefix, resolved in one green lookup.
+description: Leaf 9 sits in the 3-leaf resident frontier beyond one completed tile.
+takeaway: Its local sibling is blue, but the final left sibling is the entire 8-leaf tiled prefix, resolved in one green lookup.
 order: 3
-leaves: 300
-focus: 271
+leaves: 11
+focus: 9
 second: none

--- a/tools/proof-viz/scenarios/near-boundary.scenario
+++ b/tools/proof-viz/scenarios/near-boundary.scenario
@@ -1,9 +1,9 @@
 name: near-boundary
 proof: inclusion
 title: One leaf short of the next tile
-description: At 511 leaves, the first tile is durable and the next 255 leaves still form the frontier.
-takeaway: The 255-leaf frontier is not a perfect subtree, so no single lookup answers it: seven blue resident ranges of doubling size stack up before one green 256-leaf sibling closes the proof.
+description: At 15 leaves, the first tile is durable and the next 7 leaves still form the frontier.
+takeaway: The 7-leaf frontier is not a perfect subtree, so no single lookup answers it: blue resident ranges stack up before one green 8-leaf sibling closes the proof.
 order: 4
-leaves: 511
-focus: 510
+leaves: 15
+focus: 14
 second: none

--- a/tools/proof-viz/scenarios/next-frontier.scenario
+++ b/tools/proof-viz/scenarios/next-frontier.scenario
@@ -1,9 +1,9 @@
 name: next-frontier
 proof: inclusion
-title: A new frontier after two tiles
-description: Leaf 512 is the first resident leaf after a 512-leaf tiled prefix.
-takeaway: The proof begins with one blue leaf and crosses immediately to a single green 512-leaf sibling that represents both completed tiles.
+title: A new frontier after a level-1 tile
+description: Leaf 64 is the first resident leaf after a 64-leaf tiled prefix spanning two tile levels.
+takeaway: The proof begins with one blue leaf and crosses immediately to a single green 64-leaf sibling resolved from the level-1 tile.
 order: 6
-leaves: 513
-focus: 512
+leaves: 65
+focus: 64
 second: none

--- a/tools/proof-viz/scenarios/tile-to-frontier.scenario
+++ b/tools/proof-viz/scenarios/tile-to-frontier.scenario
@@ -1,9 +1,9 @@
 name: tile-to-frontier
 proof: inclusion
 title: A proof leaves the tiled past
-description: Leaf 42 is already represented by the first full tile, while leaves 256-299 remain resident in memory.
-takeaway: The proof starts in green tile storage, then needs blue frontier subtrees to complete the current 300-leaf root.
+description: Leaf 2 is already represented by the first full tile, while leaves 8-10 remain resident in memory.
+takeaway: The proof starts in green tile storage, then needs blue frontier subtrees to complete the current 11-leaf root.
 order: 2
-leaves: 300
-focus: 42
+leaves: 11
+focus: 2
 second: none

--- a/tools/proof-viz/styles.css
+++ b/tools/proof-viz/styles.css
@@ -258,7 +258,7 @@ h1 {
 }
 
 .swatch--tile-file {
-    border: 1px dashed var(--tile);
+    border: 1px solid var(--tile);
     background: transparent;
 }
 

--- a/tools/proof-viz/styles.css
+++ b/tools/proof-viz/styles.css
@@ -84,8 +84,7 @@ code {
 
 .masthead__inner,
 .control-band__inner,
-.scene__inner,
-.method {
+.scene__inner {
     padding-inline: var(--page-gutter);
 }
 
@@ -223,12 +222,6 @@ h1 {
     background: var(--surface);
 }
 
-.method h2 {
-    margin: 5px 0 0;
-    font-size: 31px;
-    line-height: 1.1;
-}
-
 .legend {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -262,6 +255,11 @@ h1 {
 
 .swatch--tile {
     background: var(--tile);
+}
+
+.swatch--tile-file {
+    border: 1px dashed var(--tile);
+    background: transparent;
 }
 
 .swatch--frontier {
@@ -396,37 +394,17 @@ h1 {
     font-size: 12px;
 }
 
-.method {
-    display: grid;
-    grid-template-columns: minmax(200px, 280px) minmax(0, 760px);
-    gap: 32px;
-    padding-block: 48px;
-}
-
-.method__copy {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 24px;
-    color: var(--muted);
-}
-
-.method__copy p {
-    margin: 0;
-}
-
 @media (max-width: 760px) {
     body {
         font-size: 14px;
     }
 
-    .scene__inner,
-    .method {
+    .scene__inner {
         grid-template-columns: 1fr;
     }
 
     .masthead__inner,
-    .scene__inner,
-    .method {
+    .scene__inner {
         padding-block: 32px;
     }
 


### PR DESCRIPTION
## Summary
- add a compile-time tile-height parameter to tile-aware storage, writer, source, tree, and entry-bundle types
- preserve the C2SP 256-wide geometry and existing aliases as the default, while isolating alternate widths in width-qualified storage roots
- validate geometry and byte-size bounds and keep tile-cache memory bounded as widths grow
- add alternate-width coverage for storage, L0/L1/L2 rollups, proofs, lifecycle behavior, interrupted flushes, bundles, and OpenSSL hash variants

## Testing
- default tiled-storage suite: `tiles_store`, `tiles_writer`, `tiles_proofs`, `tiles_tree`, `tiles_entries`, `tiles_geometry`
- OpenSSL tiled-storage suite: `tiles_store`, `tiles_writer`, `tiles_proofs`, `tiles_tree`, `tiles_entries`, `tiles_geometry`, `tiles_hashes`