### PR TITLE
Performance exploration: cache durable tile roots for roll-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build/${{ matrix.build_type }}
       shell: bash
-      run: ctest -VV -C ${{ matrix.build_type }} --timeout 300 -E '^time_tiles$'
+      run: |
+        ctest -VV -C ${{ matrix.build_type }} --timeout 300 \
+          -E '^time_tiles(_continuous)?$'
 
     - name: Run tile benchmark
       if: matrix.build_type == 'Release'
@@ -101,7 +103,10 @@ jobs:
       shell: bash
       run: |
         set -o pipefail
-        ctest -VV -C ${{ matrix.build_type }} --timeout 300 -R '^time_tiles$' \
+        mkdir -p tile-performance
+        TILE_PERF_OUTPUT_DIR="$PWD/tile-performance" \
+          ctest -VV -C ${{ matrix.build_type }} --timeout 900 \
+            -R '^time_tiles(_continuous)?$' \
           2>&1 | tee time_tiles-output.txt
 
     - name: Publish tile benchmark summary
@@ -159,3 +164,19 @@ jobs:
           printf '| `%s` | %s |\n' "$operation" "$result" \
             >> "$GITHUB_STEP_SUMMARY"
         done <<< "$results"
+
+        python "$GITHUB_WORKSPACE/tools/summarize_tile_performance.py" \
+          tile-performance \
+          --viewer "$GITHUB_WORKSPACE/tools/tile-performance-viewer.html" \
+          --markdown >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Upload tile performance exploration
+      if: always() && matrix.build_type == 'Release'
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: tile-performance-${{ matrix.os }}-${{ matrix.compiler }}-openssl-${{ matrix.openssl }}
+        path: |
+          build/${{ matrix.build_type }}/tile-performance/
+          tools/tile-performance-viewer.html
+        if-no-files-found: error
+        retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,10 @@ doc/html
 doc/xml
 build*/
 _codeql_build_dir/
+
+# Tile performance exploration output
+tile-performance-*.csv
+tile-performance-*.json
 _codeql_detected_source_root
 coverage*.info
 coverage_html/

--- a/README.md
+++ b/README.md
@@ -90,13 +90,16 @@ including level-2 tile coverage and tile proof timing:
 
 CI enables `LONG_TESTS` in Release configurations so pull requests exercise the
 full tiled-storage matrix; Debug configurations run the short suite. Every
-Release job publishes its `time_tiles` measurements as a table in the GitHub
-Actions job summary.
+Release job publishes its `time_tiles` measurements and the continuous
+tiled-storage performance exploration as tables in the GitHub Actions job
+summary. The downloadable artifact includes machine-readable event/cycle data
+and `tools/tile-performance-viewer.html`; no generated benchmark results are
+tracked.
 
 | CMake option | Default | Purpose |
 |---|---:|---|
 | `BUILD_TESTING` | `ON` | Build tests; set `OFF` for a library-only build |
-| `LONG_TESTS` | `OFF` | Include level-2 tile and `time_tiles` coverage |
+| `LONG_TESTS` | `OFF` | Include level-2 tile and tile performance coverage |
 | `OPENSSL` | `OFF` | Enable OpenSSL hashes, SHA-384/512 tiled aliases, and tests |
 | `CLANG_TIDY` | `OFF` | Run clang-tidy while compiling tests |
 | `TRACE` | `OFF` | Enable internal Merkle-tree trace output |

--- a/doc/tiles-guide.rst
+++ b/doc/tiles-guide.rst
@@ -112,6 +112,19 @@ complete since the previous call. Full tiles are immutable: written once after
 all 256 entries are final and never rewritten. The remaining frontier stays in
 memory until it crosses the next full-tile boundary.
 
+The writer also keeps an opportunistic per-level FIFO of perfect roots computed
+from the exact hashes passed to each successful durable tile write. A parent
+roll-up consumes matching roots in order instead of reading and hashing those
+child tiles again. Each active level retains at most one tile width of roots
+(256 with the default geometry). This changes neither the tile format nor the
+source of truth: a fresh or moved ``TiledTree``, a resumed ``TileWriter``, a
+pre-existing tile, an index gap, an interrupted write, an evicted root, or any
+other cache miss reads the immutable child tile and recomputes its root. The
+tradeoff is one perfect-root calculation during each normal tile write in
+exchange for avoiding the concentrated read-and-hash work at parent boundaries.
+The FIFO adds no synchronization; the external locking requirements above still
+apply.
+
 Tile files are written through unique temporary files, synced, then published
 with an atomic replace. On POSIX, file contents are synced, each newly created
 directory is made durable by syncing its parent, and the destination directory
@@ -166,6 +179,40 @@ Protect compacted tile files from external deletion or truncation. Once a
 tile's leaves are no longer resident, ``flush()`` cannot regenerate a missing or
 malformed copy and throws an error naming the first non-resident leaf. Restore
 the tile from backup; retrying alone cannot recover it.
+
+Performance exploration
+-----------------------
+
+``LONG_TESTS=ON`` builds ``time_tiles_continuous``. It runs 512 cycles of 256
+appends (131,072 total) against ``TiledTree``, timing each append followed by one
+``flush()`` and one ``compact()`` per cycle. A matching plain ``merkle::Tree``
+control times the same appends and calls ``flush_to(max_index())`` every 256
+leaves; it performs no tile flush or roll-up. Both roots are checked against the
+same reference.
+
+The same executable separately measures a level-0 durable write, reads of 256
+child tiles, the 65,280 SHA-256 operations needed for their perfect roots, and a
+level-1 durable write. Set ``TILE_PERF_OUTPUT_DIR`` to select the artifact
+directory:
+
+.. code:: console
+
+   cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DLONG_TESTS=ON
+   cmake --build build-release --target time_tiles_continuous
+   TILE_PERF_OUTPUT_DIR="$PWD/tile-performance" \
+     ./build-release/test/time_tiles_continuous
+   python3 tools/summarize_tile_performance.py tile-performance \
+     --viewer tools/tile-performance-viewer.html --markdown
+
+The output directory contains per-event CSV, per-cycle CSV, and a JSON summary.
+Open ``tools/tile-performance-viewer.html`` locally and choose the event CSV for
+an interactive canvas plot with linear/log scales and data-driven roll-up
+markers. Individual append observations subtract a median back-to-back
+``steady_clock`` calibration recorded in the JSON; because append operations are
+close to timer resolution, treat those values as comparative exploration rather
+than standalone microbenchmarks. Generated CSV/JSON results are measurements,
+not source, and must not be committed. Release CI runs the benchmark once,
+validates and summarizes those files, then uploads them with the tracked viewer.
 
 .. code:: cpp
 

--- a/merklecpp_tiles.h
+++ b/merklecpp_tiles.h
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <deque>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -868,6 +869,10 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
     /// written; they are therefore immutable and written exactly once.
     /// Entries beyond the last full-tile boundary remain in memory until a
     /// later flush completes the next tile.
+    /// @note After a tile is durable, its root is retained in a bounded
+    /// per-level FIFO for the next parent roll-up. The FIFO is only a performance
+    /// optimisation: every miss recomputes the root from the immutable child
+    /// tile, so restarts and discontinuities do not affect correctness or format.
     /// @warning No internal synchronization is provided. Callers must serialize
     /// access to a writer and its store.
     /// @warning A writer trusts existing full tiles as output from the same
@@ -905,10 +910,28 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       {
         /// @brief Number of full tiles written.
         uint64_t full_written = 0;
+
+        /// @brief Number of child-tile roots consumed from the write FIFO.
+        uint64_t root_fifo_hits = 0;
+
+        /// @brief Number of child-tile roots recomputed from durable tiles.
+        uint64_t root_fifo_misses = 0;
       };
 
       /// @brief Constructs a writer over @p store.
       explicit TileWriterT(Store& store) : store(store) {}
+
+      TileWriterT(const TileWriterT&) = default;
+      TileWriterT& operator=(const TileWriterT&) = delete;
+
+      /// @brief Moves writer progress while dropping opportunistic FIFO state.
+      TileWriterT(TileWriterT&& other) noexcept :
+        store(other.store),
+        next_full(std::move(other.next_full)),
+        cursor_inited(std::move(other.cursor_inited))
+      {}
+
+      TileWriterT& operator=(TileWriterT&&) = delete;
 
       /// @brief Writes all newly-complete full tiles for a tree of @p size
       /// leaves.
@@ -954,9 +977,10 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
             {
               continue; // immutable: never rewrite an existing full tile
             }
-            store.write_tile(
-              TileRef{level, n},
-              collect(level, n * TILE_WIDTH, TILE_WIDTH, leaf_at));
+            auto hashes = collect(
+              level, n * static_cast<uint64_t>(TILE_WIDTH), TILE_WIDTH, leaf_at, stats);
+            store.write_tile(TileRef{level, n}, hashes);
+            cache_written_root(level, n, hashes);
             stats.full_written++;
           }
           if (full_tiles > next_full[level])
@@ -979,6 +1003,15 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
       /// @brief Per-level flag indicating next_full has been initialised.
       std::vector<uint8_t> cursor_inited;
 
+      struct RootFifo
+      {
+        uint64_t first_index = 0;
+        std::deque<Hash> roots;
+      };
+
+      /// @brief Recently written roots, bounded to one tile width per level.
+      std::vector<RootFifo> root_fifos;
+
       /// @brief Number of complete level-@p level entries for a tree of @p
       /// size.
       static uint64_t entries_at_level(uint64_t size, uint8_t level)
@@ -997,6 +1030,69 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
           next_full.resize(needed, 0);
           cursor_inited.resize(needed, 0);
         }
+        if (root_fifos.size() < needed)
+        {
+          root_fifos.resize(needed);
+        }
+      }
+
+      /// @brief Number of roots currently retained for @p level.
+      [[nodiscard]] size_t root_fifo_size(uint8_t level) const
+      {
+        return level < root_fifos.size() ? root_fifos[level].roots.size() : 0;
+      }
+
+      void cache_written_root(
+        uint8_t level, uint64_t index, const std::vector<Hash>& hashes)
+      {
+        ensure_level(level);
+        auto& fifo = root_fifos[level];
+        const auto fifo_size = static_cast<uint64_t>(fifo.roots.size());
+        const bool index_follows_fifo =
+          !fifo.roots.empty() &&
+          fifo_size <=
+            std::numeric_limits<uint64_t>::max() - fifo.first_index &&
+          fifo.first_index + fifo_size == index;
+        if (!index_follows_fifo)
+        {
+          fifo.roots.clear();
+          fifo.first_index = index;
+        }
+
+        fifo.roots.push_back(
+          perfect_root<HASH_SIZE, HASH_FUNCTION>(hashes));
+        if (fifo.roots.size() > TILE_WIDTH)
+        {
+          fifo.roots.pop_front();
+          fifo.first_index++;
+        }
+      }
+
+      bool consume_cached_root(uint8_t level, uint64_t index, Hash& out)
+      {
+        if (level >= root_fifos.size())
+        {
+          return false;
+        }
+
+        auto& fifo = root_fifos[level];
+        while (!fifo.roots.empty() && fifo.first_index < index)
+        {
+          fifo.roots.pop_front();
+          fifo.first_index++;
+        }
+        if (fifo.roots.empty() || fifo.first_index != index)
+        {
+          return false;
+        }
+
+        out = fifo.roots.front();
+        fifo.roots.pop_front();
+        if (!fifo.roots.empty())
+        {
+          fifo.first_index++;
+        }
+        return true;
       }
 
       /// @brief Length of the confirmed contiguous prefix, bounded by @p limit.
@@ -1013,7 +1109,8 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
         uint8_t level,
         uint64_t first_entry,
         uint64_t count,
-        const LeafFn& leaf_at)
+        const LeafFn& leaf_at,
+        Stats& stats)
       {
         std::vector<Hash> out;
         out.reserve(count);
@@ -1026,10 +1123,20 @@ namespace merkle // NOLINT(modernize-concat-nested-namespaces)
           }
           else
           {
-            // Roll up the complete child full tile.
-            out.push_back(
-              perfect_root<HASH_SIZE, HASH_FUNCTION>(
-                store.read_tile(TileRef{(uint8_t)(level - 1), g})));
+            Hash root;
+            if (consume_cached_root((uint8_t)(level - 1), g, root))
+            {
+              stats.root_fifo_hits++;
+            }
+            else
+            {
+              // The FIFO is only an optimisation; durable child tiles are the
+              // source of truth after restarts, gaps, failures, and eviction.
+              root = perfect_root<HASH_SIZE, HASH_FUNCTION>(
+                store.read_tile(TileRef{(uint8_t)(level - 1), g}));
+              stats.root_fifo_misses++;
+            }
+            out.push_back(root);
           }
         }
         return out;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ endif()
 if(LONG_TESTS)
   add_merklecpp_test(tiles_level2 tiles_level2.cpp)
   add_merklecpp_test(time_tiles time_tiles.cpp)
+  add_merklecpp_test(time_tiles_continuous time_tiles_continuous.cpp)
   set(TILES_LEVEL2_TIMEOUT 900)
   if(WIN32)
     set(TILES_LEVEL2_TIMEOUT 3600)
@@ -59,6 +60,7 @@ if(LONG_TESTS)
   set_tests_properties(
     ${MERKLECPP_TEST_PREFIX}tiles_level2
     ${MERKLECPP_TEST_PREFIX}time_tiles
+    ${MERKLECPP_TEST_PREFIX}time_tiles_continuous
     PROPERTIES TIMEOUT ${TILES_LEVEL2_TIMEOUT}
   )
 endif()

--- a/test/tiles_tree.cpp
+++ b/test/tiles_tree.cpp
@@ -800,15 +800,23 @@ int main()
           interrupted.immutable_size() == level1_size,
           "level-1 interrupted flush seals attempted boundary");
 
+        TiledTree recovered(std::move(interrupted));
         fs::remove(blocker);
+        const auto retry_stats = recovered.flush();
         expect(
-          interrupted.flush().full_written == 1,
+          retry_stats.full_written == 1,
           "level-1 interrupted retry writes only the missing roll-up");
         expect(
-          interrupted.flushed_size() == level1_size,
+          retry_stats.root_fifo_hits == 0,
+          "level-1 moved retry has no writer FIFO state");
+        expect(
+          retry_stats.root_fifo_misses == TileStore::TILE_WIDTH,
+          "level-1 moved retry recomputes durable child roots");
+        expect(
+          recovered.flushed_size() == level1_size,
           "level-1 interrupted retry advances flushed size");
         expect(
-          interrupted.store_ref().has_full_tile(1, 0),
+          recovered.store_ref().has_full_tile(1, 0),
           "level-1 interrupted retry publishes roll-up");
 
         merkle::Tree expected;
@@ -818,9 +826,9 @@ int main()
         }
         const Hash expected_root = expected.root();
         expect(
-          interrupted.root() == expected_root,
+          recovered.root() == expected_root,
           "level-1 interrupted root matches reference");
-        const auto proof = interrupted.inclusion_proof(0, level1_size);
+        const auto proof = recovered.inclusion_proof(0, level1_size);
         expect(
           *proof == *expected.path(0),
           "level-1 interrupted inclusion matches reference");

--- a/test/tiles_writer.cpp
+++ b/test/tiles_writer.cpp
@@ -65,6 +65,18 @@ public:
   }
 };
 
+template <typename Writer>
+class RootFifoProbe : public Writer
+{
+public:
+  using Writer::Writer;
+
+  [[nodiscard]] size_t fifo_size(uint8_t level) const
+  {
+    return this->root_fifo_size(level);
+  }
+};
+
 static void overwrite_file(
   const fs::path& path, const std::vector<uint8_t>& bytes)
 {
@@ -417,6 +429,168 @@ int main()
       std::cout << "I (SHA-384 writer): OK" << '\n';
     }
 #endif
+
+    // ---- J. Newly written child roots roll up from a bounded FIFO.
+    {
+      using SmallStore = merkle::tiles::TileStoreT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+      using SmallWriter = merkle::tiles::TileWriterT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+
+      const auto hashes = make_hashes(16);
+      const auto leaf_at = [&](uint64_t i) -> const Hash& { return hashes[i]; };
+      SmallStore store(base / "j");
+      RootFifoProbe<SmallWriter> writer(store);
+      const auto stats = writer.write_up_to(hashes.size(), leaf_at);
+
+      expect(stats.full_written == 5, "J four L0 tiles and one L1 tile");
+      expect(stats.root_fifo_hits == 4, "J parent consumes four cached roots");
+      expect(stats.root_fifo_misses == 0, "J parent needs no durable reads");
+      expect(writer.fifo_size(0) == 0, "J child FIFO consumed");
+      expect(
+        writer.fifo_size(1) <= SmallStore::TILE_WIDTH,
+        "J FIFO remains bounded");
+
+      std::cout << "J (FIFO hit): OK" << '\n';
+    }
+
+    // ---- K. A fresh writer falls back for pre-existing child tiles.
+    {
+      using SmallStore = merkle::tiles::TileStoreT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+      using SmallWriter = merkle::tiles::TileWriterT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+
+      const auto hashes = make_hashes(16);
+      const auto leaf_at = [&](uint64_t i) -> const Hash& { return hashes[i]; };
+      SmallStore store(base / "k");
+      {
+        SmallWriter first(store);
+        expect(
+          first.write_up_to(8, leaf_at).full_written == 2,
+          "K first writer publishes two children");
+      }
+
+      SmallWriter restarted(store);
+      const auto stats = restarted.write_up_to(hashes.size(), leaf_at);
+      expect(stats.full_written == 3, "K restart writes two children and parent");
+      expect(stats.root_fifo_hits == 2, "K restart uses new child roots");
+      expect(
+        stats.root_fifo_misses == 2,
+        "K restart recomputes pre-existing child roots");
+
+      std::cout << "K (restart fallback): OK" << '\n';
+    }
+
+    // ---- L. A gap in newly written indices invalidates FIFO continuity.
+    {
+      using SmallStore = merkle::tiles::TileStoreT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+      using SmallWriter = merkle::tiles::TileWriterT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+
+      const auto hashes = make_hashes(16);
+      const auto leaf_at = [&](uint64_t i) -> const Hash& { return hashes[i]; };
+      SmallStore store(base / "l");
+      store.write_tile(
+        TileRef{0, 1},
+        std::vector<Hash>(hashes.begin() + 4, hashes.begin() + 8));
+
+      SmallWriter writer(store);
+      const auto stats = writer.write_up_to(hashes.size(), leaf_at);
+      expect(stats.full_written == 4, "L writes three children and parent");
+      expect(stats.root_fifo_hits == 2, "L uses post-gap child roots");
+      expect(
+        stats.root_fifo_misses == 2,
+        "L recomputes roots across pre-existing gap");
+
+      std::cout << "L (gap fallback): OK" << '\n';
+    }
+
+    // ---- M. Retry with a fresh writer after a parent-write failure falls back.
+    {
+      using SmallStore = merkle::tiles::TileStoreT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+      using SmallWriter = merkle::tiles::TileWriterT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+
+      const auto hashes = make_hashes(16);
+      const auto leaf_at = [&](uint64_t i) -> const Hash& { return hashes[i]; };
+      SmallStore store(base / "m");
+      const fs::path blocker = store.tile_path(TileRef{1, 0});
+      fs::create_directories(blocker);
+      {
+        SmallWriter interrupted(store);
+        bool threw = false;
+        try
+        {
+          (void)interrupted.write_up_to(hashes.size(), leaf_at);
+        }
+        catch (const std::exception&)
+        {
+          threw = true;
+        }
+        expect(threw, "M blocked parent write throws");
+        expect(store.has_full_tile(0, 3), "M child tiles remain durable");
+      }
+
+      fs::remove(blocker);
+      SmallWriter retry(store);
+      const auto stats = retry.write_up_to(hashes.size(), leaf_at);
+      expect(stats.full_written == 1, "M retry writes only parent");
+      expect(stats.root_fifo_hits == 0, "M retry has no stale FIFO state");
+      expect(
+        stats.root_fifo_misses == 4,
+        "M retry recomputes every durable child root");
+
+      std::cout << "M (failure fallback): OK" << '\n';
+    }
+
+    // ---- N. Moving a writer preserves cursors but drops opportunistic roots.
+    {
+      using SmallStore = merkle::tiles::TileStoreT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+      using SmallWriter = merkle::tiles::TileWriterT<
+        Hash::size_bytes,
+        merkle::Tree::hash_function,
+        2>;
+
+      const auto hashes = make_hashes(16);
+      const auto leaf_at = [&](uint64_t i) -> const Hash& { return hashes[i]; };
+      SmallStore store(base / "n");
+      SmallWriter original(store);
+      expect(
+        original.write_up_to(12, leaf_at).full_written == 3,
+        "N original writer publishes three children");
+
+      SmallWriter moved(std::move(original));
+      const auto stats = moved.write_up_to(hashes.size(), leaf_at);
+      expect(stats.full_written == 2, "N moved writer writes child and parent");
+      expect(stats.root_fifo_hits == 1, "N moved writer uses post-move root");
+      expect(
+        stats.root_fifo_misses == 3,
+        "N moved writer recomputes pre-move child roots");
+
+      std::cout << "N (move fallback): OK" << '\n';
+    }
 
     std::cout << "tiles_writer: OK" << '\n';
   }

--- a/test/time_tiles_continuous.cpp
+++ b/test/time_tiles_continuous.cpp
@@ -1,0 +1,462 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "tiles_test_util.h"
+#include "util.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <merklecpp.h>
+#include <merklecpp_tiles.h>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace fs = std::filesystem;
+using Clock = std::chrono::steady_clock;
+using merkle::Hash;
+using merkle::tiles::TiledTree;
+using merkle::tiles::TileRef;
+using merkle::tiles::TileStore;
+
+static constexpr size_t CYCLES = 512;
+static constexpr size_t BATCH_SIZE = TiledTree::TILE_WIDTH;
+static constexpr size_t APPENDS = CYCLES * BATCH_SIZE;
+static_assert(
+  BATCH_SIZE == 256, "continuous benchmark targets default geometry");
+
+struct Event
+{
+  std::string_view series;
+  uint64_t event_index;
+  size_t cycle;
+  size_t leaf_count;
+  std::string_view operation;
+  uint64_t duration_ns;
+  bool rollup;
+};
+
+struct Cycle
+{
+  size_t cycle;
+  size_t leaf_count;
+  bool rollup;
+  uint64_t tiled_append_total_ns;
+  uint64_t tiled_flush_ns;
+  uint64_t tiled_compact_ns;
+  uint64_t tiled_fifo_hits;
+  uint64_t tiled_fifo_misses;
+  uint64_t control_append_total_ns;
+  uint64_t control_flush_ns;
+};
+
+struct Distribution
+{
+  uint64_t minimum;
+  uint64_t p50;
+  uint64_t p99;
+  uint64_t maximum;
+};
+
+struct RollupBreakdown
+{
+  uint64_t level0_write_ns;
+  uint64_t read_child_tiles_ns;
+  uint64_t perfect_root_hashes_ns;
+  uint64_t level1_write_ns;
+};
+
+static uint64_t elapsed_ns(const Clock::time_point& start)
+{
+  return static_cast<uint64_t>(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - start)
+      .count());
+}
+
+static Distribution distribution(std::vector<uint64_t> values)
+{
+  if (values.empty())
+  {
+    throw std::runtime_error("cannot summarize an empty distribution");
+  }
+  std::sort(values.begin(), values.end());
+  const auto percentile = [&](size_t numerator) {
+    const size_t rank =
+      (values.size() * numerator + 99) / static_cast<size_t>(100);
+    const size_t index = std::max<size_t>(1, rank) - 1;
+    return values[index];
+  };
+  return {values.front(), percentile(50), percentile(99), values.back()};
+}
+
+static uint64_t timer_overhead_ns()
+{
+  constexpr size_t samples = 10000;
+  std::vector<uint64_t> values;
+  values.reserve(samples);
+  for (size_t sample = 0; sample < samples; sample++)
+  {
+    const auto start = Clock::now();
+    values.push_back(elapsed_ns(start));
+  }
+  return distribution(std::move(values)).p50;
+}
+
+static uint64_t adjusted_elapsed_ns(
+  const Clock::time_point& start, uint64_t overhead)
+{
+  const uint64_t observed = elapsed_ns(start);
+  return observed > overhead ? observed - overhead : 0;
+}
+
+static void require_stream(const std::ofstream& stream, const fs::path& path)
+{
+  if (!stream)
+  {
+    throw std::runtime_error("could not write " + path.string());
+  }
+}
+
+static void write_events(const fs::path& path, const std::vector<Event>& events)
+{
+  std::ofstream out(path);
+  require_stream(out, path);
+  out << "series,event_index,cycle,leaf_count,operation,duration_ns,rollup\n";
+  for (const auto& event : events)
+  {
+    out << event.series << ',' << event.event_index << ',' << event.cycle << ','
+        << event.leaf_count << ',' << event.operation << ','
+        << event.duration_ns << ',' << (event.rollup ? 1 : 0) << '\n';
+  }
+  require_stream(out, path);
+}
+
+static void write_cycles(const fs::path& path, const std::vector<Cycle>& cycles)
+{
+  std::ofstream out(path);
+  require_stream(out, path);
+  out << "cycle,leaf_count,rollup,tiled_append_total_ns,tiled_flush_ns,"
+         "tiled_compact_ns,tiled_fifo_hits,tiled_fifo_misses,"
+         "control_append_total_ns,control_flush_ns\n";
+  for (const auto& cycle : cycles)
+  {
+    out << cycle.cycle << ',' << cycle.leaf_count << ','
+        << (cycle.rollup ? 1 : 0) << ',' << cycle.tiled_append_total_ns << ','
+        << cycle.tiled_flush_ns << ',' << cycle.tiled_compact_ns << ','
+        << cycle.tiled_fifo_hits << ',' << cycle.tiled_fifo_misses << ','
+        << cycle.control_append_total_ns << ',' << cycle.control_flush_ns
+        << '\n';
+  }
+  require_stream(out, path);
+}
+
+static void write_distribution(
+  std::ofstream& out, std::string_view name, const Distribution& value)
+{
+  out << R"(    ")" << name << R"(": {"min_ns": )" << value.minimum
+      << R"(, "p50_ns": )" << value.p50 << R"(, "p99_ns": )" << value.p99
+      << R"(, "max_ns": )" << value.maximum << '}';
+}
+
+static RollupBreakdown benchmark_rollup(const fs::path& prefix)
+{
+  TileStore store(prefix);
+  const auto hashes = make_hashes(BATCH_SIZE * BATCH_SIZE);
+  std::vector<std::vector<Hash>> children;
+  children.reserve(BATCH_SIZE);
+  for (size_t tile = 0; tile < BATCH_SIZE; tile++)
+  {
+    const auto begin =
+      hashes.begin() + static_cast<std::ptrdiff_t>(tile * BATCH_SIZE);
+    children.emplace_back(
+      begin, begin + static_cast<std::ptrdiff_t>(BATCH_SIZE));
+  }
+
+  store.write_tile(TileRef{0, 0}, children[0]);
+  for (size_t tile = 1; tile + 1 < BATCH_SIZE; tile++)
+  {
+    store.write_tile(TileRef{0, static_cast<uint64_t>(tile)}, children[tile]);
+  }
+  auto start = Clock::now();
+  store.write_tile(
+    TileRef{0, static_cast<uint64_t>(BATCH_SIZE - 1)}, children.back());
+  const uint64_t level0_write_ns = elapsed_ns(start);
+
+  std::vector<std::vector<Hash>> read_children;
+  read_children.reserve(BATCH_SIZE);
+  start = Clock::now();
+  for (size_t tile = 0; tile < BATCH_SIZE; tile++)
+  {
+    read_children.push_back(
+      store.read_tile(TileRef{0, static_cast<uint64_t>(tile)}));
+  }
+  const uint64_t read_child_tiles_ns = elapsed_ns(start);
+
+  std::vector<Hash> roots;
+  roots.reserve(BATCH_SIZE);
+  start = Clock::now();
+  for (const auto& child : read_children)
+  {
+    roots.push_back(merkle::tiles::perfect_root<
+                    merkle::Tree::Hash::size_bytes,
+                    merkle::Tree::hash_function>(child));
+  }
+  const uint64_t perfect_root_hashes_ns = elapsed_ns(start);
+
+  start = Clock::now();
+  store.write_tile(TileRef{1, 0}, roots);
+  const uint64_t level1_write_ns = elapsed_ns(start);
+
+  return {
+    level0_write_ns,
+    read_child_tiles_ns,
+    perfect_root_hashes_ns,
+    level1_write_ns};
+}
+
+int main()
+{
+  try
+  {
+    const char* configured_output = std::getenv("TILE_PERF_OUTPUT_DIR");
+    const fs::path output_dir =
+      configured_output == nullptr ? fs::current_path() : configured_output;
+    fs::create_directories(output_dir);
+
+    const auto hashes = make_hashes(APPENDS);
+    const uint64_t append_timer_overhead_ns = timer_overhead_ns();
+    std::vector<Event> events;
+    events.reserve(APPENDS * 2 + CYCLES * 3);
+    std::vector<Cycle> cycles(CYCLES);
+    uint64_t event_index = 0;
+
+    const TemporaryDirectory tiled_directory("merklecpp_continuous_tiled");
+    TiledTree::Config config;
+    config.prefix = tiled_directory.path();
+    TiledTree tiled(config);
+    merkle::Tree reference;
+
+    for (size_t cycle_index = 0; cycle_index < CYCLES; cycle_index++)
+    {
+      auto& cycle = cycles[cycle_index];
+      cycle.cycle = cycle_index;
+      cycle.leaf_count = (cycle_index + 1) * BATCH_SIZE;
+      cycle.rollup = (cycle_index + 1) % BATCH_SIZE == 0;
+      cycle.tiled_append_total_ns = 0;
+      cycle.control_append_total_ns = 0;
+      cycle.control_flush_ns = 0;
+
+      for (size_t offset = 0; offset < BATCH_SIZE; offset++)
+      {
+        const size_t index = cycle_index * BATCH_SIZE + offset;
+        auto start = Clock::now();
+        tiled.append(hashes[index]);
+        const uint64_t duration =
+          adjusted_elapsed_ns(start, append_timer_overhead_ns);
+        cycle.tiled_append_total_ns += duration;
+        events.push_back(
+          {"tiled",
+           event_index++,
+           cycle_index,
+           index + 1,
+           "append",
+           duration,
+           false});
+        reference.insert(hashes[index]);
+      }
+
+      auto start = Clock::now();
+      const auto stats = tiled.flush();
+      cycle.tiled_flush_ns = elapsed_ns(start);
+      cycle.tiled_fifo_hits = stats.root_fifo_hits;
+      cycle.tiled_fifo_misses = stats.root_fifo_misses;
+      events.push_back(
+        {"tiled",
+         event_index++,
+         cycle_index,
+         cycle.leaf_count,
+         "flush",
+         cycle.tiled_flush_ns,
+         cycle.rollup});
+
+      start = Clock::now();
+      tiled.compact();
+      cycle.tiled_compact_ns = elapsed_ns(start);
+      events.push_back(
+        {"tiled",
+         event_index++,
+         cycle_index,
+         cycle.leaf_count,
+         "compact",
+         cycle.tiled_compact_ns,
+         false});
+    }
+
+    const Hash expected_root = reference.root();
+    if (tiled.root() != expected_root)
+    {
+      throw std::runtime_error("continuous tiled root mismatch");
+    }
+
+    merkle::Tree control;
+    for (size_t cycle_index = 0; cycle_index < CYCLES; cycle_index++)
+    {
+      auto& cycle = cycles[cycle_index];
+      for (size_t offset = 0; offset < BATCH_SIZE; offset++)
+      {
+        const size_t index = cycle_index * BATCH_SIZE + offset;
+        auto start = Clock::now();
+        control.insert(hashes[index]);
+        const uint64_t duration =
+          adjusted_elapsed_ns(start, append_timer_overhead_ns);
+        cycle.control_append_total_ns += duration;
+        events.push_back(
+          {"tree-control",
+           event_index++,
+           cycle_index,
+           index + 1,
+           "append",
+           duration,
+           false});
+      }
+
+      auto start = Clock::now();
+      control.flush_to(control.max_index());
+      cycle.control_flush_ns = elapsed_ns(start);
+      events.push_back(
+        {"tree-control",
+         event_index++,
+         cycle_index,
+         cycle.leaf_count,
+         "flush",
+         cycle.control_flush_ns,
+         false});
+    }
+    if (control.root() != expected_root)
+    {
+      throw std::runtime_error("plain tree control root mismatch");
+    }
+
+    std::vector<uint64_t> tiled_append;
+    std::vector<uint64_t> tiled_flush_normal;
+    std::vector<uint64_t> tiled_flush_rollup;
+    std::vector<uint64_t> tiled_compact;
+    std::vector<uint64_t> control_append;
+    std::vector<uint64_t> control_flush;
+    for (const auto& event : events)
+    {
+      auto* destination = &tiled_append;
+      if (event.series == "tree-control")
+      {
+        destination =
+          event.operation == "append" ? &control_append : &control_flush;
+      }
+      else if (event.operation == "flush")
+      {
+        destination = event.rollup ? &tiled_flush_rollup : &tiled_flush_normal;
+      }
+      else if (event.operation == "compact")
+      {
+        destination = &tiled_compact;
+      }
+      destination->push_back(event.duration_ns);
+    }
+
+    const Distribution tiled_append_summary = distribution(tiled_append);
+    const Distribution tiled_flush_normal_summary =
+      distribution(tiled_flush_normal);
+    const Distribution tiled_flush_rollup_summary =
+      distribution(tiled_flush_rollup);
+    const Distribution tiled_compact_summary = distribution(tiled_compact);
+    const Distribution control_append_summary = distribution(control_append);
+    const Distribution control_flush_summary = distribution(control_flush);
+
+    const TemporaryDirectory breakdown_directory("merklecpp_rollup_breakdown");
+    const RollupBreakdown breakdown =
+      benchmark_rollup(breakdown_directory.path());
+
+    const fs::path events_path = output_dir / "tile-performance-events.csv";
+    const fs::path cycles_path = output_dir / "tile-performance-cycles.csv";
+    const fs::path summary_path = output_dir / "tile-performance-summary.json";
+    write_events(events_path, events);
+    write_cycles(cycles_path, cycles);
+
+    std::ofstream summary(summary_path);
+    require_stream(summary, summary_path);
+    summary << "{\n"
+            << "  \"schema_version\": 1,\n"
+            << "  \"tile_width\": " << BATCH_SIZE << ",\n"
+            << "  \"cycles\": " << CYCLES << ",\n"
+            << "  \"appends\": " << APPENDS << ",\n"
+            << "  \"append_timer_overhead_ns\": " << append_timer_overhead_ns
+            << ",\n"
+            << R"(  "root": ")" << expected_root.to_string() << "\",\n"
+            << "  \"tiled\": {\n";
+    write_distribution(summary, "append", tiled_append_summary);
+    summary << ",\n";
+    write_distribution(summary, "flush_normal", tiled_flush_normal_summary);
+    summary << ",\n";
+    write_distribution(summary, "flush_rollup", tiled_flush_rollup_summary);
+    summary << ",\n";
+    write_distribution(summary, "compact", tiled_compact_summary);
+    summary << "\n  },\n  \"tree_control\": {\n";
+    write_distribution(summary, "append", control_append_summary);
+    summary << ",\n";
+    write_distribution(summary, "flush", control_flush_summary);
+    summary << "\n  },\n"
+            << "  \"rollup_breakdown\": {\n"
+            << "    \"level0_write_ns\": " << breakdown.level0_write_ns << ",\n"
+            << "    \"read_child_tiles_ns\": " << breakdown.read_child_tiles_ns
+            << ",\n"
+            << "    \"perfect_root_hashes_ns\": "
+            << breakdown.perfect_root_hashes_ns << ",\n"
+            << "    \"level1_write_ns\": " << breakdown.level1_write_ns << ",\n"
+            << "    \"child_tiles\": " << BATCH_SIZE << ",\n"
+            << "    \"parent_hashes\": " << BATCH_SIZE * (BATCH_SIZE - 1)
+            << "\n"
+            << "  }\n}\n";
+    require_stream(summary, summary_path);
+
+    std::cout << std::fixed << std::setprecision(3)
+              << "continuous_tiled: append p50/p99 " << tiled_append_summary.p50
+              << '/' << tiled_append_summary.p99 << " ns (timer overhead "
+              << append_timer_overhead_ns << " ns), normal flush "
+              << static_cast<double>(tiled_flush_normal_summary.p50) / 1e6
+              << '/'
+              << static_cast<double>(tiled_flush_normal_summary.p99) / 1e6
+              << " ms, roll-up flush "
+              << static_cast<double>(tiled_flush_rollup_summary.p50) / 1e6
+              << '/'
+              << static_cast<double>(tiled_flush_rollup_summary.p99) / 1e6
+              << " ms\n"
+              << "continuous_control: append p50/p99 "
+              << control_append_summary.p50 << '/' << control_append_summary.p99
+              << " ns, flush "
+              << static_cast<double>(control_flush_summary.p50) / 1e6 << '/'
+              << static_cast<double>(control_flush_summary.p99) / 1e6 << " ms\n"
+              << "rollup_breakdown: level0 write "
+              << static_cast<double>(breakdown.level0_write_ns) / 1e6
+              << " ms, reads "
+              << static_cast<double>(breakdown.read_child_tiles_ns) / 1e6
+              << " ms, perfect roots "
+              << static_cast<double>(breakdown.perfect_root_hashes_ns) / 1e6
+              << " ms, level1 write "
+              << static_cast<double>(breakdown.level1_write_ns) / 1e6 << " ms\n"
+              << "time_tiles_continuous: OK\n";
+  }
+  catch (const std::exception& ex)
+  {
+    std::cerr << "Error: " << ex.what() << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/tools/summarize_tile_performance.py
+++ b/tools/summarize_tile_performance.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Validate tile-performance artifacts and render a GitHub job summary."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+EVENT_COLUMNS = [
+    "series",
+    "event_index",
+    "cycle",
+    "leaf_count",
+    "operation",
+    "duration_ns",
+    "rollup",
+]
+CYCLE_COLUMNS = [
+    "cycle",
+    "leaf_count",
+    "rollup",
+    "tiled_append_total_ns",
+    "tiled_flush_ns",
+    "tiled_compact_ns",
+    "tiled_fifo_hits",
+    "tiled_fifo_misses",
+    "control_append_total_ns",
+    "control_flush_ns",
+]
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def as_nonnegative_int(value: Any, name: str) -> int:
+    require(isinstance(value, int) and value >= 0, f"{name} must be nonnegative")
+    return value
+
+
+def validate_distribution(value: Any, name: str) -> dict[str, int]:
+    require(isinstance(value, dict), f"{name} must be an object")
+    keys = ("min_ns", "p50_ns", "p99_ns", "max_ns")
+    result = {key: as_nonnegative_int(value.get(key), f"{name}.{key}") for key in keys}
+    require(
+        result["min_ns"] <= result["p50_ns"] <= result["p99_ns"] <= result["max_ns"],
+        f"{name} percentiles are not ordered",
+    )
+    return result
+
+
+def load_summary(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as source:
+        summary = json.load(source)
+    require(summary.get("schema_version") == 1, "unsupported summary schema")
+    width = as_nonnegative_int(summary.get("tile_width"), "tile_width")
+    cycles = as_nonnegative_int(summary.get("cycles"), "cycles")
+    appends = as_nonnegative_int(summary.get("appends"), "appends")
+    as_nonnegative_int(summary.get("append_timer_overhead_ns"), "append_timer_overhead_ns")
+    require(width > 1 and width & (width - 1) == 0, "tile_width must be a power of two")
+    require(cycles == 512, "continuous benchmark must contain 512 cycles")
+    require(appends == cycles * width == 131_072, "unexpected append count")
+    require(
+        isinstance(summary.get("root"), str) and len(summary["root"]) == 64,
+        "root must be a full SHA-256 hash",
+    )
+
+    tiled = summary.get("tiled")
+    control = summary.get("tree_control")
+    breakdown = summary.get("rollup_breakdown")
+    require(isinstance(tiled, dict), "tiled summary is missing")
+    require(isinstance(control, dict), "tree_control summary is missing")
+    require(isinstance(breakdown, dict), "rollup_breakdown is missing")
+    for key in ("append", "flush_normal", "flush_rollup", "compact"):
+        validate_distribution(tiled.get(key), f"tiled.{key}")
+    for key in ("append", "flush"):
+        validate_distribution(control.get(key), f"tree_control.{key}")
+    for key in (
+        "level0_write_ns",
+        "read_child_tiles_ns",
+        "perfect_root_hashes_ns",
+        "level1_write_ns",
+    ):
+        as_nonnegative_int(breakdown.get(key), f"rollup_breakdown.{key}")
+    require(breakdown.get("child_tiles") == width, "breakdown child tile count mismatch")
+    require(
+        breakdown.get("parent_hashes") == width * (width - 1),
+        "breakdown parent hash count mismatch",
+    )
+    return summary
+
+
+def read_csv(path: Path, columns: list[str]) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as source:
+        reader = csv.DictReader(source)
+        require(reader.fieldnames == columns, f"{path.name} columns do not match schema")
+        rows = list(reader)
+    return rows
+
+
+def parse_event_number(row: dict[str, str], key: str) -> int:
+    try:
+        value = int(row[key])
+    except (KeyError, ValueError) as exc:
+        raise ValueError(f"invalid event {key}") from exc
+    require(value >= 0, f"event {key} must be nonnegative")
+    return value
+
+
+def validate_events(path: Path, summary: dict[str, Any]) -> None:
+    rows = read_csv(path, EVENT_COLUMNS)
+    appends = summary["appends"]
+    cycles = summary["cycles"]
+    expected = appends * 2 + cycles * 3
+    require(len(rows) == expected, f"expected {expected} events, got {len(rows)}")
+
+    counts: dict[tuple[str, str], int] = {}
+    rollups = 0
+    for expected_index, row in enumerate(rows):
+        require(
+            parse_event_number(row, "event_index") == expected_index,
+            "event_index must be contiguous",
+        )
+        parse_event_number(row, "cycle")
+        parse_event_number(row, "leaf_count")
+        parse_event_number(row, "duration_ns")
+        require(row["series"] in ("tiled", "tree-control"), "unknown event series")
+        require(row["operation"] in ("append", "flush", "compact"), "unknown operation")
+        require(row["rollup"] in ("0", "1"), "rollup must be 0 or 1")
+        key = (row["series"], row["operation"])
+        counts[key] = counts.get(key, 0) + 1
+        if row["rollup"] == "1":
+            require(key == ("tiled", "flush"), "only tiled flushes mark roll-ups")
+            rollups += 1
+
+    require(counts.get(("tiled", "append")) == appends, "tiled append count mismatch")
+    require(counts.get(("tiled", "flush")) == cycles, "tiled flush count mismatch")
+    require(counts.get(("tiled", "compact")) == cycles, "tiled compact count mismatch")
+    require(counts.get(("tree-control", "append")) == appends, "control append count mismatch")
+    require(counts.get(("tree-control", "flush")) == cycles, "control flush count mismatch")
+    require(rollups == cycles // summary["tile_width"], "roll-up marker count mismatch")
+
+
+def validate_cycles(path: Path, summary: dict[str, Any]) -> None:
+    rows = read_csv(path, CYCLE_COLUMNS)
+    require(len(rows) == summary["cycles"], "cycle row count mismatch")
+    width = summary["tile_width"]
+    for index, row in enumerate(rows):
+        require(int(row["cycle"]) == index, "cycle indices must be contiguous")
+        require(int(row["leaf_count"]) == (index + 1) * width, "cycle leaf count mismatch")
+        is_rollup = (index + 1) % width == 0
+        require(int(row["rollup"]) == int(is_rollup), "cycle roll-up marker mismatch")
+        for key in CYCLE_COLUMNS[3:]:
+            require(int(row[key]) >= 0, f"{key} must be nonnegative")
+        require(int(row["tiled_fifo_misses"]) == 0, "continuous writer unexpectedly missed FIFO")
+        require(
+            int(row["tiled_fifo_hits"]) == (width if is_rollup else 0),
+            "continuous writer FIFO hit count mismatch",
+        )
+
+
+def validate_viewer(path: Path) -> None:
+    source = path.read_text(encoding="utf-8")
+    for token in (
+        "<canvas",
+        "linear",
+        "log",
+        "rollup",
+        "#276be9",
+        "#00843f",
+        "#f66a0a",
+        "#d72d47",
+    ):
+        require(token in source, f"viewer is missing {token!r}")
+
+
+def duration(value: int) -> str:
+    if value < 1_000:
+        return f"{value} ns"
+    if value < 1_000_000:
+        return f"{value / 1_000:.3f} us"
+    return f"{value / 1_000_000:.3f} ms"
+
+
+def markdown(summary: dict[str, Any]) -> str:
+    tiled = summary["tiled"]
+    control = summary["tree_control"]
+    breakdown = summary["rollup_breakdown"]
+    lines = [
+        "### Continuous tiled-storage exploration",
+        "",
+        f"{summary['cycles']} cycles, {summary['appends']:,} appends, "
+        f"tile width {summary['tile_width']}. Roots verified against the plain tree control.",
+        "",
+        "| Series / operation | p50 | p99 |",
+        "|---|---:|---:|",
+    ]
+    for label, value in (
+        ("Tiled append", tiled["append"]),
+        ("Tiled normal flush", tiled["flush_normal"]),
+        ("Tiled roll-up flush", tiled["flush_rollup"]),
+        ("Tiled compact", tiled["compact"]),
+        ("Tree control append", control["append"]),
+        ("Tree control `flush_to(max_index())`", control["flush"]),
+    ):
+        lines.append(
+            f"| {label} | {duration(value['p50_ns'])} | "
+            f"{duration(value['p99_ns'])} |"
+        )
+    lines.extend(
+        [
+            "",
+            "| Roll-up phase | Duration |",
+            "|---|---:|",
+            f"| Level-0 durable write | {duration(breakdown['level0_write_ns'])} |",
+            f"| Read {breakdown['child_tiles']} child tiles | "
+            f"{duration(breakdown['read_child_tiles_ns'])} |",
+            f"| {breakdown['parent_hashes']:,} SHA-256 parent hashes | "
+            f"{duration(breakdown['perfect_root_hashes_ns'])} |",
+            f"| Level-1 durable write | {duration(breakdown['level1_write_ns'])} |",
+            "",
+            f"Per-append values subtract a calibrated "
+            f"{summary['append_timer_overhead_ns']} ns steady-clock overhead.",
+            "",
+            "The downloadable artifact contains the raw CSV/JSON and interactive viewer.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--viewer", required=True, type=Path)
+    parser.add_argument("--markdown", action="store_true")
+    args = parser.parse_args()
+
+    summary = load_summary(args.output_dir / "tile-performance-summary.json")
+    validate_events(args.output_dir / "tile-performance-events.csv", summary)
+    validate_cycles(args.output_dir / "tile-performance-cycles.csv", summary)
+    validate_viewer(args.viewer)
+    if args.markdown:
+        print(markdown(summary))
+    else:
+        print("tile performance artifacts: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tile-performance-viewer.html
+++ b/tools/tile-performance-viewer.html
@@ -1,0 +1,264 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>merklecpp tiled-storage performance explorer</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f6f8fa;
+      --panel: #fff;
+      --text: #1f2328;
+      --muted: #59636e;
+      --border: #d1d9e0;
+      --append: #276be9;
+      --flush: #00843f;
+      --compact: #f66a0a;
+      --rollup: #d72d47;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 24px;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 system-ui, sans-serif;
+    }
+    main { max-width: 1500px; margin: auto; }
+    h1 { margin: 0 0 4px; font-size: 24px; }
+    p { color: var(--muted); margin: 0 0 18px; }
+    .toolbar, .chart {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+    }
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px 24px;
+      align-items: center;
+      margin-bottom: 14px;
+    }
+    label { display: inline-flex; gap: 7px; align-items: center; }
+    input[type=file] { max-width: 360px; }
+    select, input[type=file] {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--panel);
+      color: var(--text);
+      padding: 6px 8px;
+    }
+    .legend { display: flex; flex-wrap: wrap; gap: 12px; }
+    .swatch { width: 12px; height: 12px; border-radius: 2px; }
+    .chart { min-height: 620px; position: relative; }
+    canvas { display: block; width: 100%; height: 570px; }
+    #status { margin-top: 10px; color: var(--muted); }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117; --panel: #161b22; --text: #f0f6fc;
+        --muted: #8b949e; --border: #30363d;
+      }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <h1>Tiled-storage performance explorer</h1>
+  <p>Load <code>tile-performance-events.csv</code>. Append latency uses the right Y axis; flush and compact use the left.</p>
+  <section class="toolbar">
+    <label>Events CSV <input id="file" type="file" accept=".csv,text/csv"></label>
+    <label>Scale
+      <select id="scale">
+        <option value="log">log</option>
+        <option value="linear">linear</option>
+      </select>
+    </label>
+    <label><input id="tiled" type="checkbox" checked> tiled</label>
+    <label><input id="control" type="checkbox"> tree control</label>
+    <span class="legend">
+      <label><span class="swatch" style="background:#276be9"></span>append</label>
+      <label><span class="swatch" style="background:#00843f"></span>flush</label>
+      <label><span class="swatch" style="background:#f66a0a"></span>compact</label>
+      <label><span class="swatch" style="background:#d72d47"></span>roll-up</label>
+    </span>
+  </section>
+  <section class="chart">
+    <canvas id="plot" aria-label="Tile performance latency plot"></canvas>
+    <div id="status">Choose the generated events CSV to begin.</div>
+  </section>
+</main>
+<script>
+(() => {
+  "use strict";
+  const colors = {
+    append: "#276be9", flush: "#00843f", compact: "#f66a0a", rollup: "#d72d47"
+  };
+  const canvas = document.querySelector("#plot");
+  const context = canvas.getContext("2d");
+  const status = document.querySelector("#status");
+  const controls = ["scale", "tiled", "control"].map(id => document.querySelector(`#${id}`));
+  let events = [];
+
+  function parseCsv(text) {
+    const lines = text.trim().split(/\r?\n/);
+    const expected = "series,event_index,cycle,leaf_count,operation,duration_ns,rollup";
+    if (lines.shift() !== expected) throw new Error("Unexpected events CSV schema");
+    return lines.map(line => {
+      const values = line.split(",");
+      if (values.length !== 7) throw new Error("Malformed events CSV row");
+      return {
+        series: values[0],
+        eventIndex: Number(values[1]),
+        cycle: Number(values[2]),
+        leaves: Number(values[3]),
+        operation: values[4],
+        milliseconds: Number(values[5]) / 1e6,
+        rollup: values[6] === "1"
+      };
+    });
+  }
+
+  function resize() {
+    const ratio = window.devicePixelRatio || 1;
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = Math.max(1, Math.round(rect.width * ratio));
+    canvas.height = Math.max(1, Math.round(rect.height * ratio));
+    context.setTransform(ratio, 0, 0, ratio, 0, 0);
+    draw();
+  }
+
+  function extent(values) {
+    let maximum = 0;
+    let minimum = Infinity;
+    for (const value of values) {
+      if (value > maximum) maximum = value;
+      if (value > 0 && value < minimum) minimum = value;
+    }
+    return {minimum: minimum === Infinity ? 0.000001 : minimum, maximum: maximum || 1};
+  }
+
+  function axisTransform(value, range, logarithmic) {
+    if (!logarithmic) return value / range.maximum;
+    const floor = Math.max(range.minimum, 0.000001);
+    const low = Math.log10(floor);
+    const high = Math.log10(Math.max(range.maximum, floor * 10));
+    return (Math.log10(Math.max(value, floor)) - low) / (high - low);
+  }
+
+  function drawAxis(x, top, bottom, range, side, logarithmic) {
+    context.strokeStyle = getComputedStyle(document.documentElement).getPropertyValue("--border");
+    context.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--muted");
+    context.lineWidth = 1;
+    context.beginPath();
+    context.moveTo(x, top);
+    context.lineTo(x, bottom);
+    context.stroke();
+    context.font = "12px system-ui";
+    context.textAlign = side === "left" ? "right" : "left";
+    const align = side === "left" ? -8 : 8;
+    const formatDuration = value => {
+      if (range.maximum < 0.001) return `${(value * 1e6).toFixed(0)} ns`;
+      if (range.maximum < 1) return `${(value * 1e3).toFixed(2)} us`;
+      return `${value.toFixed(value < 10 ? 2 : 1)} ms`;
+    };
+    for (let tick = 0; tick <= 4; tick++) {
+      const fraction = tick / 4;
+      const y = bottom - fraction * (bottom - top);
+      const value = logarithmic
+        ? 10 ** (Math.log10(range.minimum) + fraction *
+            (Math.log10(Math.max(range.maximum, range.minimum * 10)) - Math.log10(range.minimum)))
+        : fraction * range.maximum;
+      context.fillText(formatDuration(value), x + align, y + 4);
+    }
+  }
+
+  function draw() {
+    const width = canvas.clientWidth;
+    const height = canvas.clientHeight;
+    context.clearRect(0, 0, width, height);
+    if (!events.length) return;
+
+    const showTiled = document.querySelector("#tiled").checked;
+    const showControl = document.querySelector("#control").checked;
+    const selected = events.filter(event =>
+      (event.series === "tiled" && showTiled) ||
+      (event.series === "tree-control" && showControl));
+    if (!selected.length) return;
+
+    const logarithmic = document.querySelector("#scale").value === "log";
+    const margin = {left: 82, right: 82, top: 24, bottom: 48};
+    const left = margin.left;
+    const right = width - margin.right;
+    const top = margin.top;
+    const bottom = height - margin.bottom;
+    let maxLeaves = 1;
+    for (const event of selected) maxLeaves = Math.max(maxLeaves, event.leaves);
+    const appendRange = extent(selected.filter(e => e.operation === "append").map(e => e.milliseconds));
+    const ioRange = extent(selected.filter(e => e.operation !== "append").map(e => e.milliseconds));
+    const x = leaves => left + leaves / maxLeaves * (right - left);
+    const y = (value, range) =>
+      bottom - axisTransform(value, range, logarithmic) * (bottom - top);
+
+    context.save();
+    context.beginPath();
+    context.rect(left, top, right - left, bottom - top);
+    context.clip();
+    context.globalAlpha = showTiled && showControl ? 0.55 : 0.8;
+
+    for (const operation of ["append", "flush", "compact"]) {
+      const points = selected.filter(event => event.operation === operation);
+      context.fillStyle = colors[operation];
+      const radius = operation === "append" ? 0.65 : 2.2;
+      const range = operation === "append" ? appendRange : ioRange;
+      for (const point of points) {
+        context.fillRect(
+          x(point.leaves) - radius,
+          y(point.milliseconds, range) - radius,
+          radius * 2,
+          radius * 2);
+      }
+    }
+
+    context.globalAlpha = 0.9;
+    context.strokeStyle = colors.rollup;
+    context.lineWidth = 1.5;
+    for (const event of selected.filter(event => event.rollup)) {
+      const marker = x(event.leaves);
+      context.beginPath();
+      context.moveTo(marker, top);
+      context.lineTo(marker, bottom);
+      context.stroke();
+    }
+    context.restore();
+
+    drawAxis(left, top, bottom, ioRange, "left", logarithmic);
+    drawAxis(right, top, bottom, appendRange, "right", logarithmic);
+    context.fillStyle = getComputedStyle(document.documentElement).getPropertyValue("--muted");
+    context.textAlign = "center";
+    context.fillText(`leaf count (0 - ${maxLeaves.toLocaleString()})`, (left + right) / 2, height - 12);
+    status.textContent =
+      `${selected.length.toLocaleString()} events rendered; ` +
+      `${selected.filter(event => event.rollup).length} data-driven roll-up markers.`;
+  }
+
+  document.querySelector("#file").addEventListener("change", async event => {
+    try {
+      const file = event.target.files[0];
+      if (!file) return;
+      events = parseCsv(await file.text());
+      draw();
+    } catch (error) {
+      events = [];
+      status.textContent = error.message;
+      draw();
+    }
+  });
+  controls.forEach(control => control.addEventListener("change", draw));
+  window.addEventListener("resize", resize);
+  resize();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Performance exploration

This is a **draft performance-exploration PR stacked on #56**, targeting `achamayou/tiles-docs`. It does not modify PR #56; review this commit as the layer above it.

### Experiment

- Retain each successfully written tile's perfect root in a bounded per-level FIFO (`first_index` plus at most one tile width of hashes).
- Consume matching roots in order during parent roll-up, moving the 255 hashes per tile into normal flushes instead of concentrating 65,280 hashes at each level-1 boundary.
- Treat the FIFO as strictly opportunistic: moves, restarts, pre-existing tiles, gaps, interrupted writes, eviction, and cache misses read immutable child tiles and recompute. Tile format, correctness, durability, and external locking are unchanged.
- Add focused FIFO hit and move/restart/gap/failure fallback coverage.

### Tracked performance exploration

`time_tiles_continuous` runs 512 cycles / 131,072 appends at the default width 256, with a tiled flush then compact every 256 leaves. A matching plain `merkle::Tree` control calls `flush_to(max_index())` every 256 leaves. Both roots are verified.

The run emits per-event CSV, per-cycle CSV, and JSON summaries, plus a separate phase breakdown for a level-0 durable write, 256 child-tile reads, 65,280 SHA-256 parent hashes, and a level-1 durable write. Release jobs run benchmarks once, validate/summarize those artifacts in the job summary, and upload them with the tracked dependency-free HTML canvas viewer. Generated results are ignored and not committed.

### Native WSL2/ext4 measurements

| Measurement | Before FIFO | With FIFO |
|---|---:|---:|
| Normal flush p50 | 2.635 ms | 2.909 ms |
| Normal flush p99 | 3.763 ms | 4.359 ms |
| Level-1 spike, run 1 | 49.589 ms | 7.686 ms |
| Level-1 spike, run 2 | 47.388 ms | 5.661 ms |

The level-1 spikes are **85–88% lower**; append and compact latency were unchanged. The uncached phase breakdown was 4.5–5.9 ms reading child tiles, 38.7–45.8 ms computing perfect roots, 4.8–5.9 ms durably writing level 1, and 2.8–3.9 ms for the final level-0 write.

### Validation

- `tiles_writer`, `tiles_tree`, `tiles_proofs`, `tiles_level2`
- legacy `time_tiles` and new `time_tiles_continuous` Release benchmarks
- Clang/clang-tidy builds for all targeted tests and direct `merklecpp_tiles.h` clang-tidy
- generated CSV/JSON schema, counts, FIFO markers, root checks, summary parser
- workflow YAML parsing and browser-loaded viewer

### Caveats

This is exploration rather than a claimed cross-platform benchmark. Results above are native WSL2/ext4 measurements and filesystem durability costs vary. Individual append observations are close to clock resolution, so artifacts record and subtract a calibrated timer overhead and should be interpreted comparatively. The FIFO deliberately adds one perfect-root calculation to each normal durable tile write and uses bounded per-active-level memory to reduce concentrated parent roll-up latency.