### PR TITLE
Validate tree deserialisation bounds

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -98,7 +98,7 @@ namespace merkle
   {
     const auto value = deserialise_uint64_t(bytes, index);
     if constexpr (
-      std::numeric_limits<size_t>::digits <
+      std::numeric_limits<size_t>::digits < // NOLINT(misc-redundant-expression)
       std::numeric_limits<uint64_t>::digits)
     {
       if (value > std::numeric_limits<size_t>::max())

--- a/merklecpp.h
+++ b/merklecpp.h
@@ -734,11 +734,17 @@ namespace merkle
         {
           return false;
         }
-        const size_t max_size = height == size_digits ?
-          std::numeric_limits<size_t>::max() :
-          (size_t{1} << height) - 1;
+        const size_t max_size = full_size(height);
         assert(size <= max_size);
         return size == max_size;
+      }
+
+      static size_t full_size(uint8_t height)
+      {
+        constexpr size_t size_digits = std::numeric_limits<size_t>::digits;
+        assert(height <= size_digits);
+        return height == size_digits ? std::numeric_limits<size_t>::max() :
+                                       (size_t{1} << height) - 1;
       }
 
       /// @brief Updates the tree size and height of the subtree under a node
@@ -1548,14 +1554,32 @@ namespace merkle
       clear();
 
       const size_t num_leaf_nodes = deserialise_size_t(bytes, position);
-      num_flushed = deserialise_size_t(bytes, position);
+      const size_t deserialised_num_flushed =
+        deserialise_size_t(bytes, position);
+
+      // A binary tree has 2 * leaves - 1 nodes, which must fit in Node::size.
+      constexpr size_t max_num_leaves =
+        std::numeric_limits<size_t>::max() / 2 + 1;
+      if (
+        deserialised_num_flushed > max_num_leaves ||
+        num_leaf_nodes > max_num_leaves - deserialised_num_flushed)
+      {
+        throw std::runtime_error("serialised tree exceeds platform limits");
+      }
+
+      size_t num_hashes = num_leaf_nodes;
+      for (size_t it = deserialised_num_flushed; it != 0; it >>= 1)
+      {
+        num_hashes += it & 0x01;
+      }
       if (
         position > bytes.size() ||
-        num_leaf_nodes > (bytes.size() - position) / HASH_SIZE)
+        num_hashes > (bytes.size() - position) / HASH_SIZE)
       {
         throw std::runtime_error("not enough bytes");
       }
 
+      num_flushed = deserialised_num_flushed;
       leaf_nodes.reserve(num_leaf_nodes);
       for (size_t i = 0; i < num_leaf_nodes; i++)
       {
@@ -1576,7 +1600,7 @@ namespace merkle
           MERKLECPP_TRACE(MERKLECPP_TOUT << "+";);
           auto n = Node::make(h);
           n->height = level_no + 1;
-          n->size = (1 << n->height) - 1;
+          n->size = Node::full_size(n->height);
           assert(n->invariant());
           level.insert(level.begin(), n);
         }

--- a/merklecpp.h
+++ b/merklecpp.h
@@ -97,9 +97,14 @@ namespace merkle
     const std::vector<uint8_t>& bytes, size_t& index)
   {
     const auto value = deserialise_uint64_t(bytes, index);
-    if (value > std::numeric_limits<size_t>::max())
+    if constexpr (
+      std::numeric_limits<size_t>::digits <
+      std::numeric_limits<uint64_t>::digits)
     {
-      throw std::runtime_error("serialised value exceeds platform limits");
+      if (value > std::numeric_limits<size_t>::max())
+      {
+        throw std::runtime_error("serialised value exceeds platform limits");
+      }
     }
     return static_cast<size_t>(value);
   }
@@ -1556,6 +1561,11 @@ namespace merkle
       const size_t num_leaf_nodes = deserialise_size_t(bytes, position);
       const size_t deserialised_num_flushed =
         deserialise_size_t(bytes, position);
+
+      if (num_leaf_nodes == 0 && deserialised_num_flushed != 0)
+      {
+        throw std::runtime_error("serialised tree has no retained leaves");
+      }
 
       // A binary tree has 2 * leaves - 1 nodes, which must fit in Node::size.
       constexpr size_t max_num_leaves =

--- a/merklecpp.h
+++ b/merklecpp.h
@@ -93,6 +93,17 @@ namespace merkle
     return r;
   }
 
+  static inline size_t deserialise_size_t(
+    const std::vector<uint8_t>& bytes, size_t& index)
+  {
+    const auto value = deserialise_uint64_t(bytes, index);
+    if (value > std::numeric_limits<size_t>::max())
+    {
+      throw std::runtime_error("serialised value exceeds platform limits");
+    }
+    return static_cast<size_t>(value);
+  }
+
   static inline bool decode_hex_digit(char c, uint8_t& value)
   {
     if ('0' <= c && c <= '9')
@@ -433,9 +444,9 @@ namespace merkle
       MERKLECPP_TRACE(MERKLECPP_TOUT << "> PathT::deserialise " << std::endl);
       elements.clear();
       _leaf.deserialise(bytes, position);
-      _leaf_index = deserialise_uint64_t(bytes, position);
-      _max_index = deserialise_uint64_t(bytes, position);
-      size_t const num_elements = deserialise_uint64_t(bytes, position);
+      _leaf_index = deserialise_size_t(bytes, position);
+      _max_index = deserialise_size_t(bytes, position);
+      size_t const num_elements = deserialise_size_t(bytes, position);
       for (size_t i = 0; i < num_elements; i++)
       {
         HashT<HASH_SIZE> hash(bytes, position);
@@ -604,6 +615,19 @@ namespace merkle
         auto r = new Node();
         r->left = r->right = nullptr;
         r->hash = hash;
+        r->dirty = false;
+        r->update_sizes();
+        assert(r->invariant());
+        return r;
+      }
+
+      /// @brief Constructs a new tree node
+      /// @param hash The hash to move into the node
+      static Node* make(HashT<HASH_SIZE>&& hash)
+      {
+        auto r = new Node();
+        r->left = r->right = nullptr;
+        r->hash = std::move(hash);
         r->dirty = false;
         r->update_sizes();
         assert(r->invariant());
@@ -1523,14 +1547,19 @@ namespace merkle
 
       clear();
 
-      size_t num_leaf_nodes = deserialise_uint64_t(bytes, position);
-      num_flushed = deserialise_uint64_t(bytes, position);
+      const size_t num_leaf_nodes = deserialise_size_t(bytes, position);
+      num_flushed = deserialise_size_t(bytes, position);
+      if (
+        position > bytes.size() ||
+        num_leaf_nodes > (bytes.size() - position) / HASH_SIZE)
+      {
+        throw std::runtime_error("not enough bytes");
+      }
 
       leaf_nodes.reserve(num_leaf_nodes);
       for (size_t i = 0; i < num_leaf_nodes; i++)
       {
-        Node* n = Node::make(bytes.data() + position);
-        position += HASH_SIZE;
+        Node* n = Node::make(Hash(bytes, position));
         leaf_nodes.push_back(n);
       }
 

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -279,6 +279,14 @@ TEST_CASE("Empty tree")
 
 TEST_CASE("TreeT rejects invalid serialised leaf data")
 {
+  for (size_t size = 0; size < 2 * sizeof(uint64_t); size++)
+  {
+    CAPTURE(size);
+    const std::vector<uint8_t> truncated_header(size, 0);
+    REQUIRE_THROWS_AS(
+      (void)merkle::Tree(truncated_header), std::out_of_range);
+  }
+
   std::vector<uint8_t> excessive_count;
   merkle::serialise_uint64_t(
     std::numeric_limits<uint64_t>::max(), excessive_count);
@@ -294,6 +302,16 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
   REQUIRE_THROWS_WITH_AS(
     (void)merkle::Tree(truncated_hashes),
     "not enough bytes",
+    std::runtime_error);
+
+  std::vector<uint8_t> no_retained_leaves;
+  merkle::serialise_uint64_t(0, no_retained_leaves);
+  merkle::serialise_uint64_t(1, no_retained_leaves);
+  no_retained_leaves.resize(
+    no_retained_leaves.size() + merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(no_retained_leaves),
+    "serialised tree has no retained leaves",
     std::runtime_error);
 
   std::vector<uint8_t> overflowing_leaf_count;

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -295,6 +295,53 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
     (void)merkle::Tree(truncated_hashes),
     "not enough bytes",
     std::runtime_error);
+
+  std::vector<uint8_t> overflowing_leaf_count;
+  merkle::serialise_uint64_t(1, overflowing_leaf_count);
+  merkle::serialise_uint64_t(
+    std::numeric_limits<size_t>::max(), overflowing_leaf_count);
+  overflowing_leaf_count.resize(
+    overflowing_leaf_count.size() + merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(overflowing_leaf_count),
+    "serialised tree exceeds platform limits",
+    std::runtime_error);
+
+  std::vector<uint8_t> unrepresentable_tree_size;
+  merkle::serialise_uint64_t(1, unrepresentable_tree_size);
+  merkle::serialise_uint64_t(
+    std::numeric_limits<size_t>::max() / 2 + 1, unrepresentable_tree_size);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(unrepresentable_tree_size),
+    "serialised tree exceeds platform limits",
+    std::runtime_error);
+
+  std::vector<uint8_t> truncated_extra_hash;
+  merkle::serialise_uint64_t(1, truncated_extra_hash);
+  merkle::serialise_uint64_t(1, truncated_extra_hash);
+  truncated_extra_hash.resize(
+    truncated_extra_hash.size() + merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(truncated_extra_hash),
+    "not enough bytes",
+    std::runtime_error);
+}
+
+TEST_CASE("TreeT deserialises flushed counts beyond signed shift width")
+{
+  constexpr auto flushed_bit = std::numeric_limits<int>::digits;
+  if constexpr (flushed_bit + 1 < std::numeric_limits<size_t>::digits)
+  {
+    const size_t num_flushed = size_t{1} << flushed_bit;
+    std::vector<uint8_t> bytes;
+    merkle::serialise_uint64_t(1, bytes);
+    merkle::serialise_uint64_t(num_flushed, bytes);
+    bytes.resize(bytes.size() + 2 * merkle::Hash::size_bytes);
+
+    merkle::Tree tree(bytes);
+    REQUIRE(tree.num_leaves() == num_flushed + 1);
+    REQUIRE(tree.size() == 2 * num_flushed + 1);
+  }
 }
 
 TEST_CASE("One-node tree")

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -277,6 +277,26 @@ TEST_CASE("Empty tree")
   REQUIRE_NOTHROW(merkle::Tree dt(buffer)); // NOLINT(misc-const-correctness)
 }
 
+TEST_CASE("TreeT rejects invalid serialised leaf data")
+{
+  std::vector<uint8_t> excessive_count;
+  merkle::serialise_uint64_t(
+    std::numeric_limits<uint64_t>::max(), excessive_count);
+  merkle::serialise_uint64_t(0, excessive_count);
+  REQUIRE_THROWS_AS(
+    (void)merkle::Tree(excessive_count), std::runtime_error);
+
+  std::vector<uint8_t> truncated_hashes;
+  merkle::serialise_uint64_t(2, truncated_hashes);
+  merkle::serialise_uint64_t(0, truncated_hashes);
+  truncated_hashes.resize(
+    truncated_hashes.size() + merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(truncated_hashes),
+    "not enough bytes",
+    std::runtime_error);
+}
+
 TEST_CASE("One-node tree")
 {
   merkle::Tree::Hash h;


### PR DESCRIPTION
## Summary

Hardens `TreeT` and `PathT` deserialisation against malformed count fields, truncated headers and hash payloads, count wraparound, unrepresentable tree metadata, and undefined shifts while rebuilding large flushed prefixes.

## Changes

### Validate serialised counts against the platform

Serialised indexes and counts are encoded as `uint64_t`, while the in-memory APIs use `size_t`. The new `deserialise_size_t()` helper reads the wire value first and rejects it if it cannot be represented by the current platform. An `if constexpr` removes the comparison entirely when `size_t` is at least as wide as `uint64_t`.

This check now covers:

- path leaf indexes
- path maximum indexes
- path element counts
- retained tree leaf counts
- flushed tree leaf counts

This prevents silent narrowing before values are used as loop bounds, vector capacities, indexes, or arithmetic operands on platforms where `size_t` is narrower than `uint64_t`.

### Reject invalid or unrepresentable tree sizes before allocation

A serialised tree with flushed leaves but no retained leaf cannot be reconstructed and is rejected. The deserialiser also validates the combined flushed and retained leaf count before reserving or allocating nodes. A binary tree containing `N` leaves has `2 * N - 1` nodes, and `Node::size` stores that node count in a `size_t`.

The maximum accepted leaf count is therefore:

```cpp
std::numeric_limits<size_t>::max() / 2 + 1
```

The subtraction-based check avoids overflowing while combining the two serialised counts. It prevents:

- `num_flushed + num_leaf_nodes` wrapping in `num_leaves()`
- `Node::size` overflowing during reconstruction
- malformed input producing a tree height unsupported by the in-memory representation

### Preflight the complete hash payload

The serialized tree contains one hash for each retained leaf plus one reconstructed left-edge hash for every set bit in `num_flushed`. The deserialiser now counts both groups before allocating any nodes:

```text
required hashes = retained leaves + popcount(num_flushed)
```

The required count is compared with the remaining byte length using division, avoiding multiplication overflow. Truncated retained-leaf or flushed-subtree data is rejected before reconstruction begins, which also avoids leaking partially allocated raw nodes when a later hash read throws.

### Use bounds-checked retained-leaf parsing

Retained hashes are now constructed with `Hash(bytes, position)` rather than reading from `bytes.data() + position`. This centralises the byte-range check and advances the cursor only through the existing hash deserialisation path.

A `Node::make()` rvalue overload accepts the validated temporary hash directly while preserving `Node`'s aggregate semantics.

### Make full-subtree sizing width-safe

Reconstruction previously used:

```cpp
(1 << height) - 1
```

The literal `1` is a 32-bit `int` on supported platforms, so a sufficiently large flushed count could shift it by 32 or more bits, causing undefined behavior.

`Node::full_size()` now performs the calculation with `size_t{1}` and handles `height == std::numeric_limits<size_t>::digits` explicitly by returning `SIZE_MAX`. The same helper is reused by `Node::is_full()` so both paths use identical boundary handling.

## Regression coverage

The added tests cover:

- every truncation point in the two-field serialized header
- a serialised count that exceeds the platform's `size_t`
- fewer retained hashes than the declared leaf count
- flushed leaves without any retained leaf
- a retained leaf combined with `num_flushed == SIZE_MAX`
- a combined leaf count whose `2 * N - 1` node count cannot fit in `size_t`
- a missing flushed-subtree hash
- successful reconstruction above the signed-`int` shift-width boundary

## Testing

- full Debug build with repository clang-tidy checks enabled
- all 19 unit and serialization test executables
- full pull-request CI matrix and CodeQL