### PR TITLE
Make tree deserialisation exception-safe

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1589,17 +1589,19 @@ namespace merkle
         throw std::runtime_error("not enough bytes");
       }
 
-      num_flushed = deserialised_num_flushed;
-      leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<Node*> deserialised_leaf_nodes;
+      deserialised_leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<std::unique_ptr<Node>> level;
+      level.reserve(num_leaf_nodes);
       for (size_t i = 0; i < num_leaf_nodes; i++)
       {
-        Node* n = Node::make(Hash(bytes, position));
-        leaf_nodes.push_back(n);
+        auto n = std::unique_ptr<Node>(Node::make(Hash(bytes, position)));
+        deserialised_leaf_nodes.push_back(n.get());
+        level.push_back(std::move(n));
       }
 
-      std::vector<Node*> level = leaf_nodes;
-      std::vector<Node*> next_level;
-      size_t it = num_flushed;
+      std::vector<std::unique_ptr<Node>> next_level;
+      size_t it = deserialised_num_flushed;
       uint8_t level_no = 0;
       while (it != 0 || level.size() > 1)
       {
@@ -1608,11 +1610,11 @@ namespace merkle
         {
           Hash h(bytes, position);
           MERKLECPP_TRACE(MERKLECPP_TOUT << "+";);
-          auto n = Node::make(h);
+          auto n = std::unique_ptr<Node>(Node::make(std::move(h)));
           n->height = level_no + 1;
           n->size = Node::full_size(n->height);
           assert(n->invariant());
-          level.insert(level.begin(), n);
+          level.insert(level.begin(), std::move(n));
         }
 
         MERKLECPP_TRACE(
@@ -1625,11 +1627,15 @@ namespace merkle
         {
           if (i + 1 >= level.size())
           {
-            next_level.push_back(level.at(i));
+            next_level.push_back(std::move(level.at(i)));
           }
           else
           {
-            next_level.push_back(Node::make(level.at(i), level.at(i + 1)));
+            auto parent = std::unique_ptr<Node>(
+              Node::make(level.at(i).get(), level.at(i + 1).get()));
+            level.at(i).release();
+            level.at(i + 1).release();
+            next_level.push_back(std::move(parent));
           }
         }
 
@@ -1644,9 +1650,11 @@ namespace merkle
 
       if (level.size() == 1)
       {
-        _root = level.at(0);
+        _root = level.at(0).release();
         assert(_root->invariant());
       }
+      leaf_nodes = std::move(deserialised_leaf_nodes);
+      num_flushed = deserialised_num_flushed;
     }
 
     /// @brief Operator to serialise the tree

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -343,6 +343,16 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
     (void)merkle::Tree(truncated_extra_hash),
     "not enough bytes",
     std::runtime_error);
+
+  std::vector<uint8_t> truncated_flushed_hashes;
+  merkle::serialise_uint64_t(1, truncated_flushed_hashes);
+  merkle::serialise_uint64_t(3, truncated_flushed_hashes);
+  truncated_flushed_hashes.resize(
+    truncated_flushed_hashes.size() + 2 * merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(truncated_flushed_hashes),
+    "not enough bytes",
+    std::runtime_error);
 }
 
 TEST_CASE("TreeT deserialises flushed counts beyond signed shift width")


### PR DESCRIPTION
## Summary

- reconstruct deserialised leaves and intermediate levels under `std::unique_ptr` ownership instead of assembling a raw-pointer forest
- keep the non-owning leaf-pointer index local until reconstruction succeeds
- transfer child ownership only after parent allocation succeeds, then release the completed root and publish `leaf_nodes` and `num_flushed` as the final commit step

## Rationale

The tree stores its completed structure as raw pointers owned recursively by the root. During deserialisation, however, there is no root owner until reconstruction finishes. The previous implementation placed newly allocated leaves and intermediate nodes directly in raw-pointer containers, so an exception during reconstruction could strand every node built so far.

The lower bounds-checking PR now rejects known malformed encodings before allocation, but reconstruction still contains throwing operations, including node allocation and vector growth, and must remain safe if later reconstruction work introduces another exception. This PR gives the in-progress forest explicit RAII ownership without changing the successful tree representation.

## Ownership and cleanup guarantees

- each leaf is wrapped in a `std::unique_ptr` immediately after allocation; the temporary leaf index contains non-owning aliases only
- when combining two children, both remain independently owned until `Node::make(left, right)` succeeds; ownership is released only after the new parent has taken responsibility for recursively deleting them
- unpaired nodes move to the next level without losing ownership
- if allocation, insertion, or level rebuilding throws, the owning vectors destroy every complete or partial subtree automatically
- member `leaf_nodes` and `num_flushed` are not published until the root is complete, so a failed deserialisation leaves no partially published tree state
- on success, exactly one completed root is released into `_root`; its existing recursive destructor owns all descendants, while `leaf_nodes` remains the tree's non-owning leaf index

## Malformed input coverage

The lower PR validates platform-size limits and the full serialized hash count before reconstruction, including truncated resident leaves and missing flushed-edge hashes. This PR retains a regression with one resident leaf, `num_flushed == 3`, and only one of the two required flushed-edge hashes. It must fail with `not enough bytes`; combined with sanitizer execution, this covers the stacked malformed-input path while the ownership changes protect any exception that occurs after allocation begins.

## Testing

Clang 21.1.8 Debug build with AddressSanitizer, LeakSanitizer (`detect_leaks=1`), and UndefinedBehaviorSanitizer:

- `TreeT rejects invalid serialised leaf data`
- `TreeT deserialises flushed counts beyond signed shift width`
- `Empty tree`
- `One-node tree`
- `Three-node tree`

Result: 5 test cases passed, 65 assertions passed.