### PR TITLE
Make tree reconstruction exception-safe

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1562,8 +1562,9 @@ namespace merkle
 
       clear();
 
-      const size_t num_leaf_nodes = deserialise_size_t(bytes, position);
-      num_flushed = deserialise_size_t(bytes, position);
+      const auto num_leaf_nodes = deserialise_size_t(bytes, position);
+      const auto deserialised_num_flushed =
+        deserialise_size_t(bytes, position);
       if (
         position > bytes.size() ||
         num_leaf_nodes > (bytes.size() - position) / HASH_SIZE)
@@ -1571,16 +1572,19 @@ namespace merkle
         throw std::runtime_error("not enough bytes");
       }
 
-      leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<Node*> deserialised_leaf_nodes;
+      deserialised_leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<std::unique_ptr<Node>> level;
+      level.reserve(num_leaf_nodes);
       for (size_t i = 0; i < num_leaf_nodes; i++)
       {
-        Node* n = Node::make(Hash(bytes, position));
-        leaf_nodes.push_back(n);
+        auto n = std::unique_ptr<Node>(Node::make(Hash(bytes, position)));
+        deserialised_leaf_nodes.push_back(n.get());
+        level.push_back(std::move(n));
       }
 
-      std::vector<Node*> level = leaf_nodes;
-      std::vector<Node*> next_level;
-      size_t it = num_flushed;
+      std::vector<std::unique_ptr<Node>> next_level;
+      size_t it = deserialised_num_flushed;
       uint8_t level_no = 0;
       while (it != 0 || level.size() > 1)
       {
@@ -1589,11 +1593,11 @@ namespace merkle
         {
           Hash h(bytes, position);
           MERKLECPP_TRACE(MERKLECPP_TOUT << "+";);
-          auto n = Node::make(h);
+          auto n = std::unique_ptr<Node>(Node::make(h));
           n->height = level_no + 1;
           n->size = (1 << n->height) - 1;
           assert(n->invariant());
-          level.insert(level.begin(), n);
+          level.insert(level.begin(), std::move(n));
         }
 
         MERKLECPP_TRACE(
@@ -1606,11 +1610,15 @@ namespace merkle
         {
           if (i + 1 >= level.size())
           {
-            next_level.push_back(level.at(i));
+            next_level.push_back(std::move(level.at(i)));
           }
           else
           {
-            next_level.push_back(Node::make(level.at(i), level.at(i + 1)));
+            auto parent = std::unique_ptr<Node>(
+              Node::make(level.at(i).get(), level.at(i + 1).get()));
+            level.at(i).release();
+            level.at(i + 1).release();
+            next_level.push_back(std::move(parent));
           }
         }
 
@@ -1625,9 +1633,11 @@ namespace merkle
 
       if (level.size() == 1)
       {
-        _root = level.at(0);
+        _root = level.at(0).release();
         assert(_root->invariant());
       }
+      leaf_nodes = std::move(deserialised_leaf_nodes);
+      num_flushed = deserialised_num_flushed;
     }
 
     /// @brief Operator to serialise the tree

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -295,6 +295,16 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
     (void)merkle::Tree(truncated_hashes),
     "not enough bytes",
     std::runtime_error);
+
+  std::vector<uint8_t> truncated_flushed_hashes;
+  merkle::serialise_uint64_t(1, truncated_flushed_hashes);
+  merkle::serialise_uint64_t(3, truncated_flushed_hashes);
+  truncated_flushed_hashes.resize(
+    truncated_flushed_hashes.size() + 2 * merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(truncated_flushed_hashes),
+    "not enough bytes",
+    std::runtime_error);
 }
 
 TEST_CASE("One-node tree")


### PR DESCRIPTION
## Summary
- own retained leaves and reconstructed levels with `std::unique_ptr` until they are linked into a parent or finalized as the root
- publish reconstructed leaf pointers and flushed count only after reconstruction succeeds
- cover cleanup after truncated flushed/left-edge hash data throws

## Testing
- `ctest --test-dir build/exception-safety --output-on-failure -R "^(unit_tests|serialisation)$"` (Debug Clang build with AddressSanitizer/UBSan)