### PR TITLE
Reject unrepresentable deserialised trees

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1579,17 +1579,19 @@ namespace merkle
         throw std::runtime_error("not enough bytes");
       }
 
-      num_flushed = deserialised_num_flushed;
-      leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<Node*> deserialised_leaf_nodes;
+      deserialised_leaf_nodes.reserve(num_leaf_nodes);
+      std::vector<std::unique_ptr<Node>> level;
+      level.reserve(num_leaf_nodes);
       for (size_t i = 0; i < num_leaf_nodes; i++)
       {
-        Node* n = Node::make(Hash(bytes, position));
-        leaf_nodes.push_back(n);
+        auto n = std::unique_ptr<Node>(Node::make(Hash(bytes, position)));
+        deserialised_leaf_nodes.push_back(n.get());
+        level.push_back(std::move(n));
       }
 
-      std::vector<Node*> level = leaf_nodes;
-      std::vector<Node*> next_level;
-      size_t it = num_flushed;
+      std::vector<std::unique_ptr<Node>> next_level;
+      size_t it = deserialised_num_flushed;
       uint8_t level_no = 0;
       while (it != 0 || level.size() > 1)
       {
@@ -1598,11 +1600,11 @@ namespace merkle
         {
           Hash h(bytes, position);
           MERKLECPP_TRACE(MERKLECPP_TOUT << "+";);
-          auto n = Node::make(h);
+          auto n = std::unique_ptr<Node>(Node::make(std::move(h)));
           n->height = level_no + 1;
           n->size = Node::full_size(n->height);
           assert(n->invariant());
-          level.insert(level.begin(), n);
+          level.insert(level.begin(), std::move(n));
         }
 
         MERKLECPP_TRACE(
@@ -1615,11 +1617,15 @@ namespace merkle
         {
           if (i + 1 >= level.size())
           {
-            next_level.push_back(level.at(i));
+            next_level.push_back(std::move(level.at(i)));
           }
           else
           {
-            next_level.push_back(Node::make(level.at(i), level.at(i + 1)));
+            auto parent = std::unique_ptr<Node>(
+              Node::make(level.at(i).get(), level.at(i + 1).get()));
+            level.at(i).release();
+            level.at(i + 1).release();
+            next_level.push_back(std::move(parent));
           }
         }
 
@@ -1634,9 +1640,11 @@ namespace merkle
 
       if (level.size() == 1)
       {
-        _root = level.at(0);
+        _root = level.at(0).release();
         assert(_root->invariant());
       }
+      leaf_nodes = std::move(deserialised_leaf_nodes);
+      num_flushed = deserialised_num_flushed;
     }
 
     /// @brief Operator to serialise the tree

--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1557,6 +1557,11 @@ namespace merkle
       const size_t deserialised_num_flushed =
         deserialise_size_t(bytes, position);
 
+      if (num_leaf_nodes == 0 && deserialised_num_flushed != 0)
+      {
+        throw std::runtime_error("serialised tree has no retained leaves");
+      }
+
       // A binary tree has 2 * leaves - 1 nodes, which must fit in Node::size.
       constexpr size_t max_num_leaves =
         std::numeric_limits<size_t>::max() / 2 + 1;

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -325,6 +325,16 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
     (void)merkle::Tree(truncated_extra_hash),
     "not enough bytes",
     std::runtime_error);
+
+  std::vector<uint8_t> truncated_flushed_hashes;
+  merkle::serialise_uint64_t(1, truncated_flushed_hashes);
+  merkle::serialise_uint64_t(3, truncated_flushed_hashes);
+  truncated_flushed_hashes.resize(
+    truncated_flushed_hashes.size() + 2 * merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(truncated_flushed_hashes),
+    "not enough bytes",
+    std::runtime_error);
 }
 
 TEST_CASE("TreeT deserialises flushed counts beyond signed shift width")

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -296,6 +296,16 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
     "not enough bytes",
     std::runtime_error);
 
+  std::vector<uint8_t> no_retained_leaves;
+  merkle::serialise_uint64_t(0, no_retained_leaves);
+  merkle::serialise_uint64_t(1, no_retained_leaves);
+  no_retained_leaves.resize(
+    no_retained_leaves.size() + merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(no_retained_leaves),
+    "serialised tree has no retained leaves",
+    std::runtime_error);
+
   std::vector<uint8_t> overflowing_leaf_count;
   merkle::serialise_uint64_t(1, overflowing_leaf_count);
   merkle::serialise_uint64_t(


### PR DESCRIPTION
## Summary

- reject serialised trees whose flushed count is non-zero while their retained-leaf count is zero
- add a focused malformed-input regression that supplies the flushed-subtree hash and verifies the dedicated error

## Rationale

The normal serializer cannot produce this count combination. `flush_to(index)` removes leaves strictly before the flush boundary and retains the boundary leaf, so every non-empty serialised tree has at least one retained leaf hash. Accepting `{retained leaves: 0, flushed leaves: > 0}` constructs a flushed-only state that is outside the tree representation's invariants.

The deserializer now reports this case as `serialised tree has no retained leaves` before attempting reconstruction.

## Arithmetic limits

The lower stack layer in #78 now owns the size/count validation that this PR originally carried:

- for `L` logical leaves, `2 * L - 1` must fit in `size_t`, so the maximum representable leaf count is `SIZE_MAX / 2 + 1`
- the retained and flushed counts are checked with subtraction rather than overflowing addition
- full-subtree sizes avoid shifting by the `size_t` bit width
- the hash preflight includes retained hashes plus one flushed-subtree hash per set bit in the flushed count

This PR deliberately does not duplicate those checks. Its remaining delta is only the orthogonal representability rule that a non-empty flushed prefix must have a retained boundary leaf.

## Malformed-input cases

- retained `0`, flushed `0`: valid empty tree
- retained `> 0`, flushed `0`: valid subject to the lower layer's size and byte-count checks
- retained `> 0`, flushed `> 0`: valid subject to the same checks
- retained `0`, flushed `> 0`: rejected because no valid serializer output has a flushed-only tree

## Tests

`TreeT rejects invalid serialised leaf data` now builds a complete `{retained: 0, flushed: 1}` payload, including its required flushed-subtree hash, and checks for the dedicated `std::runtime_error` message.

Validated with the focused `unit_tests` CTest target in a Debug build.

Stacked immediately above #80 in native stack #85.