### PR TITLE
Validate representable tree sizes

### DIFF
--- a/merklecpp.h
+++ b/merklecpp.h
@@ -1565,6 +1565,15 @@ namespace merkle
       const auto num_leaf_nodes = deserialise_size_t(bytes, position);
       const auto deserialised_num_flushed =
         deserialise_size_t(bytes, position);
+      constexpr size_t max_tree_leaves =
+        (std::numeric_limits<size_t>::max() >> 1) + 1;
+      if (
+        (num_leaf_nodes == 0 && deserialised_num_flushed != 0) ||
+        num_leaf_nodes > max_tree_leaves ||
+        deserialised_num_flushed > max_tree_leaves - num_leaf_nodes)
+      {
+        throw std::runtime_error("tree size exceeds platform limits");
+      }
       if (
         position > bytes.size() ||
         num_leaf_nodes > (bytes.size() - position) / HASH_SIZE)
@@ -1595,7 +1604,10 @@ namespace merkle
           MERKLECPP_TRACE(MERKLECPP_TOUT << "+";);
           auto n = std::unique_ptr<Node>(Node::make(h));
           n->height = level_no + 1;
-          n->size = (1 << n->height) - 1;
+          constexpr size_t size_digits = std::numeric_limits<size_t>::digits;
+          n->size = n->height == size_digits ?
+            std::numeric_limits<size_t>::max() :
+            (size_t{1} << n->height) - 1;
           assert(n->invariant());
           level.insert(level.begin(), std::move(n));
         }

--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -296,6 +296,17 @@ TEST_CASE("TreeT rejects invalid serialised leaf data")
     "not enough bytes",
     std::runtime_error);
 
+  std::vector<uint8_t> excessive_tree_size;
+  merkle::serialise_uint64_t(1, excessive_tree_size);
+  merkle::serialise_uint64_t(
+    (std::numeric_limits<size_t>::max() >> 1) + 1, excessive_tree_size);
+  excessive_tree_size.resize(
+    excessive_tree_size.size() + merkle::Hash::size_bytes);
+  REQUIRE_THROWS_WITH_AS(
+    (void)merkle::Tree(excessive_tree_size),
+    "tree size exceeds platform limits",
+    std::runtime_error);
+
   std::vector<uint8_t> truncated_flushed_hashes;
   merkle::serialise_uint64_t(1, truncated_flushed_hashes);
   merkle::serialise_uint64_t(3, truncated_flushed_hashes);


### PR DESCRIPTION
## Summary
- reject deserialized retained/flushed leaf totals that cannot be represented by the tree
- restore conflated node sizes without overflowing at the maximum supported height
- cover excessive abstract tree sizes deterministically

## Testing
- `unit_tests`
- `serialisation`